### PR TITLE
NSJSONSerialization crashes

### DIFF
--- a/Source/Network.swift
+++ b/Source/Network.swift
@@ -89,7 +89,11 @@ struct Manager {
                 return nil
             }
         
-            return try! NSJSONSerialization.JSONObjectWithData(data, options: .AllowFragments)
+            do {
+                return try NSJSONSerialization.JSONObjectWithData(data, options: .AllowFragments)
+            } catch {
+                return nil
+            }
         }
         
         return JSONSerializer(data)

--- a/Source/Network.swift
+++ b/Source/Network.swift
@@ -71,14 +71,18 @@ struct Manager {
         guard let parameters = parameters else {
             return URLRequest
         }
-        
-        let data = try! NSJSONSerialization.dataWithJSONObject(parameters, options: NSJSONWritingOptions(rawValue: 0))
-        
-        let mutableURLRequest = URLRequest.mutableCopy() as! NSMutableURLRequest
-        mutableURLRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        mutableURLRequest.HTTPBody = data
-        
-        return mutableURLRequest
+
+        do {
+            let data = try NSJSONSerialization.dataWithJSONObject(parameters, options: NSJSONWritingOptions(rawValue: 0))
+
+            let mutableURLRequest = URLRequest.mutableCopy() as! NSMutableURLRequest
+            mutableURLRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            mutableURLRequest.HTTPBody = data
+
+            return mutableURLRequest
+        } catch {
+            return URLRequest
+        }
     }
     
     private func serializeResponse(data: NSData?) -> (AnyObject?) {

--- a/Tests/ClientTests.swift
+++ b/Tests/ClientTests.swift
@@ -164,11 +164,17 @@ class ClientTests: XCTestCase {
         let object = ["city": "San Francisco", "objectID": "a/go/?à"]
         
         index.addObject(object, block: { (content, error) -> Void in
+            guard let taskID = content?["taskID"] as? Int else {
+                XCTFail("Error fetching taskID")
+                expecation.fulfill()
+                return
+            }
+
             if let error = error {
                 XCTFail("Error during addObject: \(error)")
                 expecation.fulfill()
             } else {
-                self.index.waitTask(content!["taskID"] as! Int, block: { (content, error) -> Void in
+                self.index.waitTask(taskID, block: { (content, error) -> Void in
                     if let error = error {
                         XCTFail("Error during waitTask: \(error)")
                         expecation.fulfill()


### PR DESCRIPTION
We're seeing `SIGTRAP` crashes in prod on poor connections caused by the forced `try!` when serialising JSON

```
0x000a71a8 _TFFV4Manager7requestFS0_FTOS_10HTTPMethodSS10parametersGSqGVSs10DictionarySSPSs9AnyObject___5blockFTGSqCSo17NSHTTPURLResponse_GSqPS3___GSqCSo7NSError__T__VS_7RequestU_FTGSqCSo6NSData_GSqCSo13NSURLResponse_GSqS5___T_ + 190 (algoliasearch-client-swift_Network.swift:92)
```

request:
```
Method: POST	Error Code: -1001	Error: NSURLErrorTimedOut
14	/query
```

this should take care of it by not forcing the try. 