### PR TITLE
HTTP headers can now be changed during the session’s lifetime

### DIFF
--- a/Source/Network.swift
+++ b/Source/Network.swift
@@ -45,12 +45,13 @@ struct Manager {
     ///
     /// - parameter method: The HTTP method.
     /// - parameter URLString: The URL string.
+    /// - parameter HTTPHeaders: HTTP headers.
     /// - parameter parameters: The parameters (will be encoding in JSON).
     /// - parameter block: A completion handler.
     ///
     /// - returns: The created request.
-    func request(method: HTTPMethod, _ URLString: String, parameters: [String: AnyObject]? = nil, block: (NSHTTPURLResponse?, AnyObject?, NSError?) -> Void) -> Request {
-        let URLRequest = encodeParameter(CreateNSURLRequest(method, URL: URLString), parameters: parameters)
+    func request(method: HTTPMethod, _ URLString: String, HTTPHeaders: [String: String]? = nil, parameters: [String: AnyObject]? = nil, block: (NSHTTPURLResponse?, AnyObject?, NSError?) -> Void) -> Request {
+        let URLRequest = encodeParameter(CreateNSURLRequest(method, URL: URLString, HTTPHeaders: HTTPHeaders), parameters: parameters)
         
         let dataTask = session.dataTaskWithRequest(URLRequest, completionHandler: { (data, response, error) -> Void in
             let (JSON, error) = self.serializeResponse(data)
@@ -142,9 +143,13 @@ struct Request {
     }
 }
 
-func CreateNSURLRequest(method: HTTPMethod, URL: String) -> NSURLRequest {
+func CreateNSURLRequest(method: HTTPMethod, URL: String, HTTPHeaders: [String: String]?) -> NSURLRequest {
     let mutableURLRequest = NSMutableURLRequest(URL: NSURL(string: URL)!)
     mutableURLRequest.HTTPMethod = method.rawValue
-    
+    if HTTPHeaders != nil {
+        for (key, value) in HTTPHeaders! {
+            mutableURLRequest.addValue(value, forHTTPHeaderField: key)
+        }
+    }
     return mutableURLRequest
 }

--- a/Tests/ClientTests.swift
+++ b/Tests/ClientTests.swift
@@ -490,4 +490,28 @@ class ClientTests: XCTestCase {
         
         waitForExpectationsWithTimeout(expectationTimeout, handler: nil)
     }
+
+    func testHeaders() {
+        // Make a call with a valid API key.
+        let expectation1 = expectationWithDescription("Valid API key")
+        self.client.listIndexes {
+            (content, error) -> Void in
+            XCTAssertNil(error)
+            expectation1.fulfill()
+        }
+        
+        // Override the API key and check the call fails.
+        self.client.httpHeaders["X-Algolia-API-Key"] = "NOT_A_VALID_API_KEY"
+        let expectation2 = expectationWithDescription("Invalid API key")
+        self.client.listIndexes {
+            (content, error) -> Void in
+            XCTAssertNotNil(error)
+            expectation2.fulfill()
+        }
+
+        // Restore the valid API key (otherwise tear down will fail).
+        self.client.httpHeaders["X-Algolia-API-Key"] = self.client.apiKey
+        
+        waitForExpectationsWithTimeout(expectationTimeout, handler: nil)
+    }
 }


### PR DESCRIPTION
As per Apple’s docs, changing the configuration of an `NSURLSession` instance after its initialization has no effect. As a consequence, new values for HTTP headers failed to be taken into account.

Now, only immutable headers are passed during the session’s initialization. Other headers are stored in the `Client` instance, and explicitly passed at every request.

The HTTP headers are a key-value store (`[String: String]` dictionary). Dynamic properties are now built on top of this store.

NOTE: Some security-related headers have been marked as deprecated, since the preferred way is now to use secured API keys.

Fixes #13, fixes #27.