### PR TITLE
Add missing query parameters `filters` and `numericFilters`

### DIFF
--- a/Source/Query.swift
+++ b/Source/Query.swift
@@ -37,11 +37,6 @@ import Foundation
 // of the untyped storage (i.e. serializing to and parsing from string
 // values).
 //
-// ## Unmapped parameters
-//
-// Some parameters are too complex and have no typed accessors. They are
-// documented in the class's description.
-//
 // # Bridgeability
 //
 // **This Swift client must be bridgeable to Objective-C.**
@@ -153,12 +148,6 @@ public func ==(lhs: LatLng, rhs: LatLng) -> Bool {
 /// 1. Using the high-level, typed properties for individual parameters (recommended).
 /// 2. Using the low-level, untyped getter (`get()`) and setter (`set()`) or the subscript operator.
 ///    Use this approach if the parameter you wish to set is not supported by this class.
-///
-/// The following parameters have no typed property because they are too complex. You can still access them using
-/// the low-level methods/subscript operator:
-///
-/// - `filters`
-/// - `numericFilters`
 ///
 @objc public class Query : NSObject, NSCopying {
     
@@ -533,8 +522,12 @@ public func ==(lhs: LatLng, rhs: LatLng) -> Bool {
     
     // MARK: Numeric search parameters
 
-    // NOTE: `numericFilters` omitted because loosely typed (see implementation notes above).
-
+    /// Filter on numeric attributes.
+    @objc public var numericFilters: [AnyObject]? {
+        get { return Query.parseJSONArray(get("numericFilters")) }
+        set { set("numericFilters", value: Query.buildJSONArray(newValue)) }
+    }
+    
     // MARK: Category search parameters
 
     /// Filter the query by a set of tags.
@@ -588,8 +581,25 @@ public func ==(lhs: LatLng, rhs: LatLng) -> Bool {
     }
 
     // MARK: Unified filter parameter (SQL like)
-    
-    // NOTE: `filters` omitted because loosely typed (see implementation notes above).
+
+    /// Filter the query with numeric, facet or/and tag filters.
+    /// The syntax is a SQL like syntax, you can use the OR and AND keywords. The syntax for the underlying numeric,
+    /// facet and tag filters is the same than in the other filters:
+    ///
+    ///     available=1 AND (category:Book OR NOT category:Ebook) AND publication_date: 1441745506 TO 1441755506
+    ///     AND inStock > 0 AND author:"John Doe"
+    ///
+    /// The list of keywords is:
+    ///
+    /// - `OR`: create a disjunctive filter between two filters.
+    /// - `AND`: create a conjunctive filter between two filters.
+    /// - `TO`: used to specify a range for a numeric filter.
+    /// - `NOT`: used to negate a filter. The syntax with the `-` isn't allowed.
+    ///
+    @objc public var filters: String? {
+        get { return get("filters") }
+        set { set("filters", value: newValue) }
+    }
 
     // MARK: Geo-search parameters
     

--- a/Tests/IndexTests.swift
+++ b/Tests/IndexTests.swift
@@ -695,7 +695,7 @@ class IndexTests: XCTestCase {
                     } else {
                         // Delete by query.
                         let query = Query()
-                        query["numericFilters"] = "dummy < 1500"
+                        query.numericFilters = ["dummy < 1500"]
                         self.index.deleteByQuery(query, completionHandler: { (content, error) -> Void in
                             if error != nil {
                                 XCTFail(error!.localizedDescription)

--- a/Tests/QueryTests.swift
+++ b/Tests/QueryTests.swift
@@ -617,4 +617,27 @@ class QueryTests: XCTestCase {
         let query2 = Query.parse(query1.build())
         XCTAssertEqual(query2.minimumAroundRadius, 1000)
     }
+    
+    func test_numericFilters() {
+        let VALUE: [AnyObject] = ["code=1", ["price:0 to 10", "price:1000 to 2000"]]
+        let query1 = Query()
+        XCTAssertNil(query1.numericFilters)
+        query1.numericFilters = VALUE
+        XCTAssertEqual(query1.numericFilters! as NSObject, VALUE as NSObject)
+        XCTAssertEqual(query1["numericFilters"], "[\"code=1\",[\"price:0 to 10\",\"price:1000 to 2000\"]]")
+        let query2 = Query.parse(query1.build())
+        XCTAssertEqual(query2.numericFilters! as NSObject, VALUE as NSObject)
+    }
+    
+    func test_filters() {
+        let VALUE = "available=1 AND (category:Book OR NOT category:Ebook) AND publication_date: 1441745506 TO 1441755506 AND inStock > 0 AND author:\"John Doe\""
+        let query1 = Query()
+        XCTAssertNil(query1.filters)
+        query1.filters = VALUE
+        XCTAssertEqual(query1.filters, VALUE)
+        XCTAssertEqual(query1["filters"], VALUE)
+        let query2 = Query.parse(query1.build())
+        XCTAssertEqual(query2.filters, VALUE)
+    }
+    
 }


### PR DESCRIPTION
The rationale for not implementing them was that they cannot be adequately typed. However, after investigation:

- `numericFilters` has roughly the same complexity as `tagFilters` or `facetFilters`. Therefore using a JSON array type, like for those parameters, should be adequate (although suboptimal).

- `filters` is designed to be a “SQL-like notation”, so I guess a raw string type is adequate. In the future, we may want to provide tools to build the filters more easily, but this will likely come in the form of “helpers”, as it is done in the Javascript client.

Since the absence of typed properties for the missing parameters was confusing, I am adding them now.