### PR TITLE
Support iOS7

### DIFF
--- a/Source/Client.swift
+++ b/Source/Client.swift
@@ -127,7 +127,9 @@ import Foundation
         
         // Create background queue.
         self.queue = NSOperationQueue()
-        self.queue.underlyingQueue = dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0)
+        if #available(iOS 8.0, *) {
+            self.queue.underlyingQueue = dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0)
+        }
         
         super.init()
         


### PR DESCRIPTION
This change allows the library to be used on iOS 7 devices with no impact on later versions of iOS by conditionally using an iOS 8+ call.