### PR TITLE
Support iOS 7.0

### DIFF
--- a/AlgoliaSearch-Client-Swift.podspec
+++ b/AlgoliaSearch-Client-Swift.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
     s.author   = { 'Algolia' => 'contact@algolia.com' }
     s.source = { :git => 'https://github.com/algolia/algoliasearch-client-swift.git', :tag => s.version }
 
-    s.ios.deployment_target = '8.0'
+    s.ios.deployment_target = '7.0'
     s.osx.deployment_target = '10.10'
 
     # By default, do not require the offline SDK.

--- a/AlgoliaSearch.xcodeproj/project.pbxproj
+++ b/AlgoliaSearch.xcodeproj/project.pbxproj
@@ -656,7 +656,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -697,7 +697,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
@@ -791,7 +791,6 @@
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/Source/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.algolia.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = AlgoliaSearch;
@@ -813,7 +812,6 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/Source/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.algolia.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = AlgoliaSearch;
@@ -835,7 +833,6 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.algolia.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -850,7 +847,6 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.algolia.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Source/Client.swift
+++ b/Source/Client.swift
@@ -86,10 +86,6 @@ import Foundation
     // NOTE: Not constant only for the sake of mocking during unit tests.
     var session: URLSession
     
-    /// Background queue for complex asynchronous operations.
-    let queue: NSOperationQueue
-
-
     /// Create a new Algolia Search client.
     ///
     /// - parameter appID:  The application ID (available in your Algolia Dashboard).
@@ -124,10 +120,6 @@ import Foundation
         let configuration = NSURLSessionConfiguration.defaultSessionConfiguration()
         configuration.HTTPAdditionalHeaders = fixedHTTPHeaders
         session = NSURLSession(configuration: configuration)
-        
-        // Create background queue.
-        self.queue = NSOperationQueue()
-        self.queue.underlyingQueue = dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0)
         
         super.init()
         


### PR DESCRIPTION
- Move deployment target to iOS 7.0 (was 8.0).
- Remove obsolete queue in `Client` class (`underlyingQueue` property not supported on iOS 7).

Fixes #63.