### PR TITLE
Support Swift 2.3

### DIFF
--- a/AlgoliaSearch.xcodeproj/project.pbxproj
+++ b/AlgoliaSearch.xcodeproj/project.pbxproj
@@ -425,9 +425,11 @@
 					};
 					5DB2513C1AAD9EE300945339 = {
 						CreatedOnToolsVersion = 6.1.1;
+						LastSwiftMigration = 0800;
 					};
 					5DB251461AAD9EE400945339 = {
 						CreatedOnToolsVersion = 6.1.1;
+						LastSwiftMigration = 0800;
 					};
 					BCD1F5491CC61C8D0006E227 = {
 						CreatedOnToolsVersion = 7.3;
@@ -796,6 +798,7 @@
 				PRODUCT_NAME = AlgoliaSearch;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -817,6 +820,7 @@
 				PRODUCT_NAME = AlgoliaSearch;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};
@@ -837,6 +841,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.algolia.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -851,6 +856,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.algolia.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
+				SWIFT_VERSION = 2.3;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;

--- a/Tests/MockURLSession.swift
+++ b/Tests/MockURLSession.swift
@@ -68,7 +68,11 @@ public class MockURLSession: URLSession {
     let defaultResponse = MockResponse(error: NSError(domain: NSURLErrorDomain, code: NSURLErrorResourceUnavailable, userInfo: nil))
     
     public func dataTaskWithRequest(request: NSURLRequest, completionHandler: (NSData?, NSURLResponse?, NSError?) -> Void) -> NSURLSessionDataTask {
+        #if swift(>=2.3)
+        let details = responses[request.URL!.absoluteString!] ?? defaultResponse
+        #else
         let details = responses[request.URL!.absoluteString] ?? defaultResponse
+        #endif
         let task = MockURLSessionDataTask(request: request, details: details, completionHandler: completionHandler)
         task.cancellable = self.cancellable
         return task


### PR DESCRIPTION
The only incompatible change is in the tests, not the library itself. Therefore it should be transparent to any user of the module (either through CocoaPods or Carthage). For maintainers, the project seems to compile just fine with both Xcode 7.3.1 and Xcode 8 beta.

Refs #74.
