### PR TITLE
Implement the “is alive” endpoint

### DIFF
--- a/Source/Client.swift
+++ b/Source/Client.swift
@@ -281,6 +281,17 @@ import Foundation
         let body = ["requests": operations]
         return performHTTPQuery(path, method: .POST, body: body, hostnames: writeHosts, completionHandler: completionHandler)
     }
+    
+    /// Ping the server.
+    /// This method returns nothing except a message indicating that the server is alive.
+    ///
+    /// - parameter completionHandler: Completion handler to be notified of the request's outcome.
+    /// - returns: A cancellable operation.
+    ///
+    @objc public func isAlive(completionHandler: CompletionHandler) -> NSOperation {
+        let path = "1/isalive"
+        return performHTTPQuery(path, method: .GET, body: nil, hostnames: readHosts, completionHandler: completionHandler)
+    }
 
     // MARK: - Network
 

--- a/Tests/ClientTests.swift
+++ b/Tests/ClientTests.swift
@@ -336,4 +336,18 @@ class ClientTests: XCTestCase {
         }
         waitForExpectationsWithTimeout(expectationTimeout, handler: nil)
     }
+    
+    func testIsAlive() {
+        let expectation = expectationWithDescription(#function)
+        
+        client.isAlive() { (content, error) -> Void in
+            if let error = error {
+                XCTFail(error.description)
+            } else {
+                XCTAssertEqual(content?["message"] as? String, "server is alive")
+            }
+            expectation.fulfill()
+        }
+        waitForExpectationsWithTimeout(expectationTimeout, handler: nil)
+    }
 }


### PR DESCRIPTION
`Client.isAlive()` just pings `/1/isalive`.