### PR TITLE
Make completion handler mandatory on multiple queries

### DIFF
--- a/Source/Client.swift
+++ b/Source/Client.swift
@@ -281,6 +281,17 @@ import Foundation
         let body = ["requests": operations]
         return performHTTPQuery(path, method: .POST, body: body, hostnames: writeHosts, completionHandler: completionHandler)
     }
+    
+    /// Ping the server.
+    /// This method returns nothing except a message indicating that the server is alive.
+    ///
+    /// - parameter completionHandler: Completion handler to be notified of the request's outcome.
+    /// - returns: A cancellable operation.
+    ///
+    @objc public func isAlive(completionHandler: CompletionHandler) -> NSOperation {
+        let path = "1/isalive"
+        return performHTTPQuery(path, method: .GET, body: nil, hostnames: readHosts, completionHandler: completionHandler)
+    }
 
     // MARK: - Network
 

--- a/Source/Client.swift
+++ b/Source/Client.swift
@@ -240,7 +240,7 @@ import Foundation
     /// - parameter completionHandler: Completion handler to be notified of the request's outcome.
     /// - returns: A cancellable operation.
     ///
-    @objc public func multipleQueries(queries: [IndexQuery], strategy: String?, completionHandler: CompletionHandler? = nil) -> NSOperation {
+    @objc public func multipleQueries(queries: [IndexQuery], strategy: String?, completionHandler: CompletionHandler) -> NSOperation {
         // IMPLEMENTATION NOTE: Objective-C bridgeable alternative.
         var path = "1/indexes/*/queries"
         if strategy != nil {
@@ -265,7 +265,7 @@ import Foundation
     /// - parameter completionHandler: Completion handler to be notified of the request's outcome.
     /// - returns: A cancellable operation.
     ///
-    public func multipleQueries(queries: [IndexQuery], strategy: MultipleQueriesStrategy? = nil, completionHandler: CompletionHandler? = nil) -> NSOperation {
+    public func multipleQueries(queries: [IndexQuery], strategy: MultipleQueriesStrategy? = nil, completionHandler: CompletionHandler) -> NSOperation {
         // IMPLEMENTATION NOTE: Not Objective-C bridgeable because of enum.
         return multipleQueries(queries, strategy: strategy?.rawValue, completionHandler: completionHandler)
     }

--- a/Tests/ClientTests.swift
+++ b/Tests/ClientTests.swift
@@ -336,4 +336,18 @@ class ClientTests: XCTestCase {
         }
         waitForExpectationsWithTimeout(expectationTimeout, handler: nil)
     }
+    
+    func testIsAlive() {
+        let expectation = expectationWithDescription(#function)
+        
+        client.isAlive() { (content, error) -> Void in
+            if let error = error {
+                XCTFail(error.description)
+            } else {
+                XCTAssertEqual(content?["message"] as? String, "server is alive")
+            }
+            expectation.fulfill()
+        }
+        waitForExpectationsWithTimeout(expectationTimeout, handler: nil)
+    }
 }


### PR DESCRIPTION
**WARNING: Breaking change.** Multiple queries are just aggregated search queries, so it does not make any sense to ignore the results. Furthermore, it contradicts the convention adopted in the rest of the code.