### PR TITLE
Fix URL encoding of path components and query strings

### DIFF
--- a/Source/Client.swift
+++ b/Source/Client.swift
@@ -168,7 +168,7 @@ import Foundation
     /// - returns: A cancellable operation.
     ///
     @objc public func deleteIndex(indexName: String, completionHandler: CompletionHandler? = nil) -> NSOperation {
-        let path = "1/indexes/\(indexName.urlEncode())"
+        let path = "1/indexes/\(indexName.urlEncodedPathComponent())"
         return performHTTPQuery(path, method: .DELETE, body: nil, hostnames: writeHosts, completionHandler: completionHandler)
     }
 
@@ -183,7 +183,7 @@ import Foundation
     /// - returns: A cancellable operation.
     ///
     @objc public func moveIndex(srcIndexName: String, to dstIndexName: String, completionHandler: CompletionHandler? = nil) -> NSOperation {
-        let path = "1/indexes/\(srcIndexName.urlEncode())/operation"
+        let path = "1/indexes/\(srcIndexName.urlEncodedPathComponent())/operation"
         let request = [
             "destination": dstIndexName,
             "operation": "move"
@@ -203,7 +203,7 @@ import Foundation
     /// - returns: A cancellable operation.
     ///
     @objc public func copyIndex(srcIndexName: String, to dstIndexName: String, completionHandler: CompletionHandler? = nil) -> NSOperation {
-        let path = "1/indexes/\(srcIndexName.urlEncode())/operation"
+        let path = "1/indexes/\(srcIndexName.urlEncodedPathComponent())/operation"
         let request = [
             "destination": dstIndexName,
             "operation": "copy"
@@ -244,7 +244,7 @@ import Foundation
         // IMPLEMENTATION NOTE: Objective-C bridgeable alternative.
         var path = "1/indexes/*/queries"
         if strategy != nil {
-            path += "?strategy=\(strategy!.urlEncode())"
+            path += "?strategy=\(strategy!.urlEncodedQueryParam())"
         }
         var requests = [[String: AnyObject]]()
         requests.reserveCapacity(queries.count)

--- a/Source/Helpers.swift
+++ b/Source/Helpers.swift
@@ -23,11 +23,43 @@
 
 import Foundation
 
+
+// MARK: - URL encoding
+
+/// Character set allowed as a component of the path portion of a URL.
+/// Basically it's just the default `NSCharacterSet.URLPathAllowedCharacterSet()` minus the slash character.
+///
+let URLPathComponentAllowedCharacterSet: NSCharacterSet = {
+    let characterSet = NSMutableCharacterSet()
+    characterSet.formUnionWithCharacterSet(NSCharacterSet.URLPathAllowedCharacterSet())
+    characterSet.removeCharactersInString("/")
+    return characterSet
+}()
+
+// Allowed characters taken from [RFC 3986](https://tools.ietf.org/html/rfc3986) (cf. §2 "Characters"):
+// - unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~"
+// - gen-delims  = ":" / "/" / "?" / "#" / "[" / "]" / "@"
+// - sub-delims  = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "="
+//
+// ... with these further restrictions:
+// - ampersand ('&') and equal sign ('=') removed because they are used as delimiters for the parameters;
+// - question mark ('?') and hash ('#') removed because they mark the beginning and the end of the query string.
+// - plus ('+') is removed because it is interpreted as a space by Algolia's servers.
+//
+let URLQueryParamAllowedCharacterSet = NSCharacterSet(charactersInString:
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~:/[]@!$'()*,;"
+)
+
+
 extension String {
-    /// Return URL encoded version of the string
-    func urlEncode() -> String {
-        let customAllowedSet = NSCharacterSet(charactersInString: "!*'();:@&=+$,/?%#[]").invertedSet
-        return stringByAddingPercentEncodingWithAllowedCharacters(customAllowedSet)!
+    /// Return an URL-encoded version of the string suitable for use as a component of the path portion of a URL.
+    func urlEncodedPathComponent() -> String {
+        return stringByAddingPercentEncodingWithAllowedCharacters(URLPathComponentAllowedCharacterSet)!
+    }
+    
+    /// Return an URL-encoded version of the string suitable for use as a query parameter key or value.
+    func urlEncodedQueryParam() -> String {
+        return stringByAddingPercentEncodingWithAllowedCharacters(URLQueryParamAllowedCharacterSet)!
     }
 }
 

--- a/Source/Index.swift
+++ b/Source/Index.swift
@@ -37,7 +37,7 @@ import Foundation
     @objc init(client: Client, indexName: String) {
         self.client = client
         self.indexName = indexName
-        urlEncodedIndexName = indexName.urlEncode()
+        urlEncodedIndexName = indexName.urlEncodedPathComponent()
     }
 
     // MARK: - Utils
@@ -70,7 +70,7 @@ import Foundation
     /// - returns: A cancellable operation.
     ///
     @objc public func addObject(object: [String: AnyObject], withID objectID: String, completionHandler: CompletionHandler? = nil) -> NSOperation {
-        let path = "1/indexes/\(urlEncodedIndexName)/\(objectID.urlEncode())"
+        let path = "1/indexes/\(urlEncodedIndexName)/\(objectID.urlEncodedPathComponent())"
         return client.performHTTPQuery(path, method: .PUT, body: object, hostnames: client.writeHosts, completionHandler: completionHandler)
     }
     
@@ -100,7 +100,7 @@ import Foundation
     /// - returns: A cancellable operation.
     ///
     @objc public func deleteObject(objectID: String, completionHandler: CompletionHandler? = nil) -> NSOperation {
-        let path = "1/indexes/\(urlEncodedIndexName)/\(objectID.urlEncode())"
+        let path = "1/indexes/\(urlEncodedIndexName)/\(objectID.urlEncodedPathComponent())"
         return client.performHTTPQuery(path, method: .DELETE, body: nil, hostnames: client.writeHosts, completionHandler: completionHandler)
     }
     
@@ -130,7 +130,7 @@ import Foundation
     /// - returns: A cancellable operation.
     ///
     @objc public func getObject(objectID: String, completionHandler: CompletionHandler) -> NSOperation {
-        let path = "1/indexes/\(urlEncodedIndexName)/\(objectID.urlEncode())"
+        let path = "1/indexes/\(urlEncodedIndexName)/\(objectID.urlEncodedPathComponent())"
         return client.performHTTPQuery(path, method: .GET, body: nil, hostnames: client.readHosts, completionHandler: completionHandler)
     }
     
@@ -144,7 +144,7 @@ import Foundation
     @objc public func getObject(objectID: String, attributesToRetrieve attributes: [String], completionHandler: CompletionHandler) -> NSOperation {
         let query = Query()
         query.attributesToRetrieve = attributes
-        let path = "1/indexes/\(urlEncodedIndexName)/\(objectID.urlEncode())?\(query.build())"
+        let path = "1/indexes/\(urlEncodedIndexName)/\(objectID.urlEncodedPathComponent())?\(query.build())"
         return client.performHTTPQuery(path, method: .GET, body: nil, hostnames: client.readHosts, completionHandler: completionHandler)
     }
     
@@ -175,7 +175,7 @@ import Foundation
     /// - returns: A cancellable operation.
     ///
     @objc public func partialUpdateObject(partialObject: [String: AnyObject], objectID: String, completionHandler: CompletionHandler? = nil) -> NSOperation {
-        let path = "1/indexes/\(urlEncodedIndexName)/\(objectID.urlEncode())/partial"
+        let path = "1/indexes/\(urlEncodedIndexName)/\(objectID.urlEncodedPathComponent())/partial"
         return client.performHTTPQuery(path, method: .POST, body: partialObject, hostnames: client.writeHosts, completionHandler: completionHandler)
     }
     
@@ -210,7 +210,7 @@ import Foundation
     ///
     @objc public func saveObject(object: [String: AnyObject], completionHandler: CompletionHandler? = nil) -> NSOperation {
         let objectID = object["objectID"] as! String
-        let path = "1/indexes/\(urlEncodedIndexName)/\(objectID.urlEncode())"
+        let path = "1/indexes/\(urlEncodedIndexName)/\(objectID.urlEncodedPathComponent())"
         return client.performHTTPQuery(path, method: .PUT, body: object, hostnames: client.writeHosts, completionHandler: completionHandler)
     }
     
@@ -359,7 +359,7 @@ import Foundation
     /// - returns: A cancellable operation.
     ///
     @objc public func browseFrom(cursor: String, completionHandler: CompletionHandler) -> NSOperation {
-        let path = "1/indexes/\(urlEncodedIndexName)/browse?cursor=\(cursor.urlEncode())"
+        let path = "1/indexes/\(urlEncodedIndexName)/browse?cursor=\(cursor.urlEncodedQueryParam())"
         return client.performHTTPQuery(path, method: .GET, body: nil, hostnames: client.readHosts, completionHandler: completionHandler)
     }
     

--- a/Source/Query.swift
+++ b/Source/Query.swift
@@ -886,30 +886,15 @@ public func ==(lhs: LatLng, rhs: LatLng) -> Bool {
 
     // MARK: Serialization & parsing
 
-    // Allowed characters taken from [RFC 3986](https://tools.ietf.org/html/rfc3986) (cf. §2 "Characters"):
-    // - unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~"
-    // - gen-delims  = ":" / "/" / "?" / "#" / "[" / "]" / "@"
-    // - sub-delims  = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "="
-    //
-    // ... with these further restrictions:
-    // - ampersand ('&') and equal sign ('=') removed because they are used as delimiters for the parameters;
-    // - question mark ('?') and hash ('#') removed because they mark the beginning and the end of the query string.
-    // - plus ('+') is removed because it is interpreted as a space by Algolia's servers.
-    //
-    static let queryParamAllowedCharacterSet = NSCharacterSet(charactersInString:
-        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~:/[]@!$'()*,;"
-    )
-    
     /// Return the final query string used in URL.
     @objc public func build() -> String {
         var components = [String]()
         // Sort parameters by name to get predictable output.
         let sortedParameters = parameters.sort { $0.0 < $1.0 }
         for (key, value) in sortedParameters {
-            if let escapedKey = key.stringByAddingPercentEncodingWithAllowedCharacters(Query.queryParamAllowedCharacterSet),
-                let escapedValue = value.stringByAddingPercentEncodingWithAllowedCharacters(Query.queryParamAllowedCharacterSet) {
-                components.append(escapedKey + "=" + escapedValue)
-            }
+            let escapedKey = key.urlEncodedQueryParam()
+            let escapedValue = value.urlEncodedQueryParam()
+            components.append(escapedKey + "=" + escapedValue)
         }
         return components.joinWithSeparator("&")
     }

--- a/Tests/ClientTests.swift
+++ b/Tests/ClientTests.swift
@@ -336,4 +336,15 @@ class ClientTests: XCTestCase {
         }
         waitForExpectationsWithTimeout(expectationTimeout, handler: nil)
     }
+    
+    func testIndexNameWithSpace() {
+    let expectation = expectationWithDescription(#function)
+        client.deleteIndex("Index with spaces", completionHandler: { (content, error) -> Void in
+            if error != nil {
+                XCTFail(error!.localizedDescription)
+            }
+            expectation.fulfill()
+        })
+        waitForExpectationsWithTimeout(expectationTimeout, handler: nil)
+    }
 }


### PR DESCRIPTION
- Spaces must be properly escaped, otherwise the URL is invalid, and results in a crash (fixes #103).

- Query parameters have a different allowed character set and must be escaped accordingly. This was already the case inside the `Query` class, but not for the few query parameters set in the `Client` or `Index` classes. => This behavior is now factorized in the helper `String` extension.