### PR TITLE
Add support for search in facet values

### DIFF
--- a/Source/Index.swift
+++ b/Source/Index.swift
@@ -370,7 +370,7 @@ import Foundation
     /// - parameter facetName: Name of the facet to search. It must have been declared in the index's
     ///       `attributesForFaceting` setting with the `searchable()` modifier.
     /// - parameter text: Text to search for in the facet's values.
-    /// - parameter query: An optional query to take extra search parameters into account. There parameters apply to
+    /// - parameter query: An optional query to take extra search parameters into account. These parameters apply to
     ///       index objects like in a regular search query. Only facet values contained in the matched objects will be
     ///       returned.
     /// - parameter completionHandler: Completion handler to be notified of the request's outcome.

--- a/Source/Index.swift
+++ b/Source/Index.swift
@@ -363,6 +363,30 @@ import Foundation
         }
     }
     
+    /// Search in a facet.
+    /// This searches inside a facet's values, optionally restricting the returned values to those contained in objects
+    /// matching other (regular) search criteria.
+    ///
+    /// - parameter facetName: Name of the facet to search. It must have been declared in the index's
+    ///       `attributesForFaceting` setting with the `searchable()` modifier.
+    /// - parameter text: Text to search for in the facet's values.
+    /// - parameter query: An optional query to take extra search parameters into account. There parameters apply to
+    ///       index objects like in a regular search query. Only facet values contained in the matched objects will be
+    ///       returned.
+    /// - parameter completionHandler: Completion handler to be notified of the request's outcome.
+    /// - returns: A cancellable operation.
+    ///
+    @objc(searchFacet:forText:query:completionHandler:)
+    @discardableResult public func searchFacet(_ facetName: String, for text: String, query: Query? = nil, completionHandler: @escaping CompletionHandler) -> Operation {
+        let path = "1/indexes/\(urlEncodedName)/facets/\(facetName.urlEncodedPathComponent())/query"
+        let params = query != nil ? Query(copy: query!) : Query()
+        params["facetQuery"] = text
+        let requestBody = [
+            "params": params.build()
+        ]
+        return client.performHTTPQuery(path: path, method: .POST, body: requestBody, hostnames: client.readHosts, isSearchQuery: true, completionHandler: completionHandler)
+    }
+    
     /// Get this index's settings.
     ///
     /// - parameter completionHandler: Completion handler to be notified of the request's outcome.

--- a/Source/Index.swift
+++ b/Source/Index.swift
@@ -363,7 +363,7 @@ import Foundation
         }
     }
     
-    /// Search in a facet.
+    /// Search for facet values.
     /// This searches inside a facet's values, optionally restricting the returned values to those contained in objects
     /// matching other (regular) search criteria.
     ///
@@ -376,8 +376,8 @@ import Foundation
     /// - parameter completionHandler: Completion handler to be notified of the request's outcome.
     /// - returns: A cancellable operation.
     ///
-    @objc(searchFacet:forText:query:completionHandler:)
-    @discardableResult public func searchFacet(_ facetName: String, for text: String, query: Query? = nil, completionHandler: @escaping CompletionHandler) -> Operation {
+    @objc(searchForFacetValuesOf:matching:query:completionHandler:)
+    @discardableResult public func searchForFacetValues(of facetName: String, matching text: String, query: Query? = nil, completionHandler: @escaping CompletionHandler) -> Operation {
         let path = "1/indexes/\(urlEncodedName)/facets/\(facetName.urlEncodedPathComponent())/query"
         let params = query != nil ? Query(copy: query!) : Query()
         params["facetQuery"] = text

--- a/Tests/IndexTests.swift
+++ b/Tests/IndexTests.swift
@@ -1161,7 +1161,7 @@ class IndexTests: OnlineTestCase {
         self.waitForExpectations(timeout: expectationTimeout + timeout * 4, handler: nil)
     }
     
-    func testSearchInFacet() {
+    func testSearchForFacetValues() {
         let expectation = self.expectation(description: #function)
         let settings = [
             "attributesForFaceting": [
@@ -1215,7 +1215,7 @@ class IndexTests: OnlineTestCase {
                 self.index.waitTask(withID: taskID) { (content, error) in
                     guard error == nil else { XCTFail(error!.localizedDescription); expectation.fulfill(); return }
                     // Query with no extra search parameters.
-                    self.index.searchFacet("series", for: "Hobb") { (content, error) in
+                    self.index.searchForFacetValues(of: "series", matching: "Hobb") { (content, error) in
                         guard error == nil else { XCTFail(error!.localizedDescription); expectation.fulfill(); return }
                         guard let facetHits = content!["facetHits"] as? [JSONObject] else { XCTFail("No facet hits"); expectation.fulfill(); return }
                         XCTAssertEqual(facetHits.count, 1)
@@ -1225,7 +1225,7 @@ class IndexTests: OnlineTestCase {
                         let query = Query()
                         query.facetFilters = ["kind:animal"]
                         query.numericFilters = ["born >= 1955"]
-                        self.index.searchFacet("series", for: "Peanutz", query: query) { (content, error) in
+                        self.index.searchForFacetValues(of: "series", matching: "Peanutz", query: query) { (content, error) in
                             guard error == nil else { XCTFail(error!.localizedDescription); expectation.fulfill(); return }
                             guard let facetHits = content!["facetHits"] as? [JSONObject] else { XCTFail("No facet hits"); expectation.fulfill(); return }
                             XCTAssertEqual(facetHits[0]["value"] as? String, "Peanuts")

--- a/Tests/ObjectiveCBridging.m
+++ b/Tests/ObjectiveCBridging.m
@@ -237,6 +237,9 @@
     [index search:[Query new] completionHandler:^(NSDictionary<NSString*,id>* content, NSError* error) {
         // Do nothing.
     }];
+    [index searchFacet:@"facet" forText:@"text" query:nil completionHandler:^(NSDictionary<NSString *,id>* content, NSError* error) {
+        // Do nothing.
+    }];
     [index getSettings:^(NSDictionary<NSString*,id>* content, NSError* error) {
         // Do nothing.
     }];

--- a/Tests/ObjectiveCBridging.m
+++ b/Tests/ObjectiveCBridging.m
@@ -237,7 +237,7 @@
     [index search:[Query new] completionHandler:^(NSDictionary<NSString*,id>* content, NSError* error) {
         // Do nothing.
     }];
-    [index searchFacet:@"facet" forText:@"text" query:nil completionHandler:^(NSDictionary<NSString *,id>* content, NSError* error) {
+    [index searchForFacetValuesOf:@"facet" matching:@"text" query:nil completionHandler:^(NSDictionary<NSString *,id>* content, NSError* error) {
         // Do nothing.
     }];
     [index getSettings:^(NSDictionary<NSString*,id>* content, NSError* error) {


### PR DESCRIPTION
- Add a new method `Index.searchFacet(_:for:query:completionHandler:)` targeting the `POST /1/indexes/${indexName}/facets/${facetName}/query/` API endpoint.
- Swift unit test
- Objective-C bridging test
