### PR TITLE
New offline features

### DIFF
--- a/AlgoliaSearch.xcodeproj/project.pbxproj
+++ b/AlgoliaSearch.xcodeproj/project.pbxproj
@@ -135,7 +135,7 @@
 		BCD57D231D89947500C5DE68 /* DisjunctiveFaceting.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCD57D1E1D89947500C5DE68 /* DisjunctiveFaceting.swift */; };
 		BCD57D261D89970D00C5DE68 /* MultipleQueryEmulator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCD57D241D89970D00C5DE68 /* MultipleQueryEmulator.swift */; };
 		BCD57D271D89970D00C5DE68 /* OfflineIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCD57D251D89970D00C5DE68 /* OfflineIndex.swift */; };
-		BCD57D311D89B12E00C5DE68 /* AlgoliaSearch.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BC4BD2931D54E48900170ECC /* AlgoliaSearch.framework */; };
+		BCD57D311D89B12E00C5DE68 /* AlgoliaSearchOffline.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BC4BD2931D54E48900170ECC /* AlgoliaSearchOffline.framework */; };
 		BCD57D3C1D89B1EA00C5DE68 /* OfflineClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCD57D391D89B1EA00C5DE68 /* OfflineClientTests.swift */; };
 		BCD57D3D1D89B1EA00C5DE68 /* OfflineIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCD57D3A1D89B1EA00C5DE68 /* OfflineIndexTests.swift */; };
 		BCD57D3E1D89B1EA00C5DE68 /* OfflineTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCD57D3B1D89B1EA00C5DE68 /* OfflineTestCase.swift */; };
@@ -212,7 +212,7 @@
 		BC23A6EC1D63539A00DF9034 /* AlgoliaSearch.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AlgoliaSearch.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BC4A7F381CB5308100AF1DCB /* AsyncOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncOperation.swift; sourceTree = "<group>"; };
 		BC4A7F3B1CB5373E00AF1DCB /* CancelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CancelTests.swift; sourceTree = "<group>"; };
-		BC4BD2931D54E48900170ECC /* AlgoliaSearch.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AlgoliaSearch.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		BC4BD2931D54E48900170ECC /* AlgoliaSearchOffline.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AlgoliaSearchOffline.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BC4DDEEF1DD10E8B004D9A6E /* AbstractClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AbstractClient.swift; sourceTree = "<group>"; };
 		BC4DDEF51DD10EBA004D9A6E /* Types.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Types.swift; sourceTree = "<group>"; };
 		BC4DDEFB1DD11527004D9A6E /* PlacesClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlacesClient.swift; sourceTree = "<group>"; };
@@ -307,7 +307,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BCD57D311D89B12E00C5DE68 /* AlgoliaSearch.framework in Frameworks */,
+				BCD57D311D89B12E00C5DE68 /* AlgoliaSearchOffline.framework in Frameworks */,
 				3A11AC4EE771A46C306173F7 /* Pods_AlgoliaSearch_Offline_iOS_Tests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -344,7 +344,7 @@
 				5DB251471AAD9EE400945339 /* AlgoliaSearch iOS Tests.xctest */,
 				BCD1F54A1CC61C8D0006E227 /* AlgoliaSearch.framework */,
 				BCD1F5531CC61C8D0006E227 /* AlgoliaSearch tvOS Tests.xctest */,
-				BC4BD2931D54E48900170ECC /* AlgoliaSearch.framework */,
+				BC4BD2931D54E48900170ECC /* AlgoliaSearchOffline.framework */,
 				BC23A6EC1D63539A00DF9034 /* AlgoliaSearch.framework */,
 				BCD57D2C1D89B12E00C5DE68 /* AlgoliaSearch-Offline-iOS-Tests.xctest */,
 			);
@@ -607,7 +607,7 @@
 			);
 			name = "AlgoliaSearch-Offline-iOS";
 			productName = AlgoliaSarch;
-			productReference = BC4BD2931D54E48900170ECC /* AlgoliaSearch.framework */;
+			productReference = BC4BD2931D54E48900170ECC /* AlgoliaSearchOffline.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		BCD1F5491CC61C8D0006E227 /* AlgoliaSearch tvOS */ = {
@@ -1420,7 +1420,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.algolia.$(PRODUCT_NAME:rfc1034identifier)";
-				PRODUCT_NAME = AlgoliaSearch;
+				PRODUCT_NAME = AlgoliaSearchOffline;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1442,7 +1442,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.algolia.$(PRODUCT_NAME:rfc1034identifier)";
-				PRODUCT_NAME = AlgoliaSearch;
+				PRODUCT_NAME = AlgoliaSearchOffline;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/AlgoliaSearch.xcodeproj/project.pbxproj
+++ b/AlgoliaSearch.xcodeproj/project.pbxproj
@@ -143,6 +143,8 @@
 		BCDA73791CA546800082B197 /* NetworkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCDA73771CA546800082B197 /* NetworkTests.swift */; };
 		BCDA737E1CA555070082B197 /* MockURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCDA737D1CA555070082B197 /* MockURLSession.swift */; };
 		BCDA737F1CA555070082B197 /* MockURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCDA737D1CA555070082B197 /* MockURLSession.swift */; };
+		BCEE36811E0830810091D113 /* settings.json in Resources */ = {isa = PBXBuildFile; fileRef = BCEE36801E0830810091D113 /* settings.json */; };
+		BCEE36831E08309F0091D113 /* objects.json in Resources */ = {isa = PBXBuildFile; fileRef = BCEE36821E08309F0091D113 /* objects.json */; };
 		BCFC281C1D92660C00BFE0A0 /* MirroredIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFC281B1D92660C00BFE0A0 /* MirroredIndexTests.swift */; };
 		BCFC281D1D92670100BFE0A0 /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D44D0261B362648008369AC /* Helpers.swift */; };
 /* End PBXBuildFile section */
@@ -234,6 +236,8 @@
 		BCD57D3B1D89B1EA00C5DE68 /* OfflineTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OfflineTestCase.swift; sourceTree = "<group>"; };
 		BCDA73771CA546800082B197 /* NetworkTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkTests.swift; sourceTree = "<group>"; };
 		BCDA737D1CA555070082B197 /* MockURLSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockURLSession.swift; sourceTree = "<group>"; };
+		BCEE36801E0830810091D113 /* settings.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = settings.json; sourceTree = "<group>"; };
+		BCEE36821E08309F0091D113 /* objects.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = objects.json; sourceTree = "<group>"; };
 		BCFC281B1D92660C00BFE0A0 /* MirroredIndexTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MirroredIndexTests.swift; sourceTree = "<group>"; };
 		F52EEAD0E1031BA77193C0AF /* Pods_AlgoliaSearch_Offline_iOS_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AlgoliaSearch_Offline_iOS_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -450,6 +454,8 @@
 				BCD57D3A1D89B1EA00C5DE68 /* OfflineIndexTests.swift */,
 				BCD57D3B1D89B1EA00C5DE68 /* OfflineTestCase.swift */,
 				BC6267ED1D8FE4180014C767 /* OfflineObjcBridging.m */,
+				BCEE36801E0830810091D113 /* settings.json */,
+				BCEE36821E08309F0091D113 /* objects.json */,
 			);
 			path = Offline;
 			sourceTree = "<group>";
@@ -784,6 +790,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BCEE36831E08309F0091D113 /* objects.json in Resources */,
+				BCEE36811E0830810091D113 /* settings.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/Helpers.swift
+++ b/Source/Helpers.swift
@@ -120,6 +120,23 @@ extension Date {
     }
 }
 
+// MARK: - Thread synchronization
+
+extension NSObject {
+    /// Equivalent of Objective-C's `@synchronized` statement.
+    /// Actually leverages the same Objective-C runtime feature (this is why it's only available on `NSObject`).
+    ///
+    /// - paremeter block: Block to be executed serially on the object.
+    ///
+    func synchronized(_ block: () -> ()) {
+        objc_sync_enter(self)
+        defer {
+            objc_sync_exit(self)
+        }
+        block()
+    }
+}
+
 // MARK: - Miscellaneous
 
 /// The operating system's name.

--- a/Source/Index.swift
+++ b/Source/Index.swift
@@ -170,16 +170,7 @@ import Foundation
     ///
     @objc
     @discardableResult public func getObjects(withIDs objectIDs: [String], completionHandler: @escaping CompletionHandler) -> Operation {
-        let path = "1/indexes/*/objects"
-        
-        var requests = [Any]()
-        requests.reserveCapacity(objectIDs.count)
-        for id in objectIDs {
-            requests.append(["indexName": self.name, "objectID": id])
-        }
-        let request = ["requests": requests]
-        
-        return client.performHTTPQuery(path: path, method: .POST, body: request, hostnames: client.readHosts, completionHandler: completionHandler)
+        return getObjects(withIDs: objectIDs, attributesToRetrieve: nil, completionHandler: completionHandler)
     }
 
     /// Get several objects from this index, optionally restricting the retrieved content.
@@ -191,16 +182,16 @@ import Foundation
     /// - returns: A cancellable operation.
     ///
     @objc
-    @discardableResult public func getObjects(withIDs objectIDs: [String], attributesToRetrieve: [String], completionHandler: @escaping CompletionHandler) -> Operation {
+    @discardableResult public func getObjects(withIDs objectIDs: [String], attributesToRetrieve: [String]?, completionHandler: @escaping CompletionHandler) -> Operation {
         let path = "1/indexes/*/objects"
         var requests = [Any]()
         requests.reserveCapacity(objectIDs.count)
         for id in objectIDs {
-            let request = [
+            var request = [
                 "indexName": self.name,
                 "objectID": id,
-                "attributesToRetrieve": attributesToRetrieve.joined(separator: ",")
             ]
+            request["attributesToRetrieve"] = attributesToRetrieve?.joined(separator: ",")
             requests.append(request as Any)
         }
         return client.performHTTPQuery(path: path, method: .POST, body: ["requests": requests], hostnames: client.readHosts, completionHandler: completionHandler)

--- a/Source/Index.swift
+++ b/Source/Index.swift
@@ -143,19 +143,19 @@ import Foundation
     ///
     @objc
     @discardableResult public func getObject(withID objectID: String, completionHandler: @escaping CompletionHandler) -> Operation {
-        let path = "1/indexes/\(urlEncodedName)/\(objectID.urlEncodedPathComponent())"
-        return client.performHTTPQuery(path: path, method: .GET, body: nil, hostnames: client.readHosts, completionHandler: completionHandler)
+        return getObject(withID: objectID, attributesToRetrieve: nil, completionHandler: completionHandler)
     }
     
     /// Get an object from this index, optionally restricting the retrieved content.
     ///
     /// - parameter objectID: Identifier of the object to retrieve.
-    /// - parameter attributesToRetrieve: List of attributes to retrieve.
+    /// - parameter attributesToRetrieve: List of attributes to retrieve. If `nil`, all attributes are retrieved.
+    ///                                   If one of the elements is `"*"`, all attributes are retrieved.
     /// - parameter completionHandler: Completion handler to be notified of the request's outcome.
     /// - returns: A cancellable operation.
     ///
     @objc
-    @discardableResult public func getObject(withID objectID: String, attributesToRetrieve: [String], completionHandler: @escaping CompletionHandler) -> Operation {
+    @discardableResult public func getObject(withID objectID: String, attributesToRetrieve: [String]?, completionHandler: @escaping CompletionHandler) -> Operation {
         let query = Query()
         query.attributesToRetrieve = attributesToRetrieve
         let path = "1/indexes/\(urlEncodedName)/\(objectID.urlEncodedPathComponent())?\(query.build())"

--- a/Source/Offline/MirroredIndex.swift
+++ b/Source/Offline/MirroredIndex.swift
@@ -54,14 +54,14 @@ import Foundation
 /// + Note: You cannot construct this class directly. Please use `OfflineClient.index(withName:)` to obtain an
 ///   instance.
 ///
-/// + Note: Requires Algolia's SDK. The `OfflineClient.enableOfflineMode(...)` method must be called with a valid
-/// license key prior to calling any offline-related method.
+/// + Note: Requires Algolia Offline Core. The `OfflineClient.enableOfflineMode(...)` method must be called with a
+///   valid license key prior to calling any offline-related method.
 ///
 /// When created, an instance of this class has its `mirrored` flag set to false, and behaves like a normal,
 /// online `Index`. When the `mirrored` flag is set to true, the index becomes capable of acting upon local data.
 ///
 /// + Warning: It is a programming error to call methods acting on the local data when `mirrored` is false. Doing so
-/// will result in an assertion error being raised.
+///   will result in an assertion error being raised.
 ///
 ///
 /// ## Request strategy
@@ -73,9 +73,14 @@ import Foundation
 /// failure (including network unavailability).
 ///
 /// + Note: If you want to explicitly target either the online API or the offline mirror, doing so is always possible
-/// using the `searchOnline(...)` or `searchOffline(...)` methods.
+///   using `searchOnline(...)` or `searchOffline(...)`.
 ///
-/// + Note: The strategy applies both to `search(...)` and `searchDisjunctiveFaceting(...)`.
+/// + Note: The strategy applies to:
+///   - `search(...)`
+///   - `searchDisjunctiveFaceting(...)`
+///   - `multipleQueries(...)`
+///   - `getObject(...)`
+///   - `getObjects(...)`
 ///
 ///
 /// ## Bootstrapping
@@ -1093,7 +1098,7 @@ import Foundation
     /// Notification sent when the sync has finished.
     @objc public static let SyncDidFinishNotification = Notification.Name("AlgoliaSearch.MirroredIndex.SyncDidFinishNotification")
     
-    /// Notification user info key used to pass the error, when an error occurred during the sync or bootstrap.
+    /// Notification user info key used to pass the error, when an error occurred during a sync or a build.
     @objc public static let errorKey = "AlgoliaSearch.MirroredIndex.errorKey"
 
     @available(*, deprecated: 4.6, message: "Please use `errorKey` instead")

--- a/Source/Offline/MirroredIndex.swift
+++ b/Source/Offline/MirroredIndex.swift
@@ -244,6 +244,7 @@ import Foundation
     ///
     @objc public var hasOfflineData: Bool {
         get {
+            assert(mirrored, "Mirroring not activated for this index")
             return localIndex.exists()
         }
     }

--- a/Source/Offline/MirroredIndex.swift
+++ b/Source/Offline/MirroredIndex.swift
@@ -533,14 +533,20 @@ import Foundation
     /// - parameter settingsFile: Absolute path to the file containing the index settings, in JSON format.
     /// - parameter objectFiles: Absolute path(s) to the file(s) containing the objects. Each file must contain an
     ///   array of objects, in JSON format.
+    /// - parameter completionHandler: An optional completion handler to be notified when the build has finished.
     ///
-    @objc public func buildOffline(settingsFile: String, objectFiles: [String]) {
+    @objc public func buildOffline(settingsFile: String, objectFiles: [String], completionHandler: CompletionHandler? = nil) {
         assert(self.mirrored, "Mirroring not activated on this index")
         offlineClient.buildQueue.addOperation(BlockOperation() {
-            try? self._buildOffline(settingsFile: settingsFile, objectFiles: objectFiles)
+            do {
+                try self._buildOffline(settingsFile: settingsFile, objectFiles: objectFiles)
+                completionHandler?([:], nil)
+            } catch let e {
+                completionHandler?(nil, e)
+            }
         })
     }
-    
+
     /// Build the offline mirror.
     ///
     /// + Warning: This method is synchronous: it blocks until completion.

--- a/Source/Offline/MirroredIndex.swift
+++ b/Source/Offline/MirroredIndex.swift
@@ -761,12 +761,7 @@ import Foundation
     @discardableResult public func searchOnline(_ query: Query, completionHandler: @escaping CompletionHandler) -> Operation {
         return super.search(query, completionHandler: {
             (content, error) in
-            // Tag results as having a remote origin.
-            var taggedContent: JSONObject? = content
-            if taggedContent != nil {
-                taggedContent?[MirroredIndex.jsonKeyOrigin] = MirroredIndex.jsonValueOriginRemote
-            }
-            completionHandler(taggedContent, error)
+            completionHandler(MirroredIndex.tagAsRemote(content: content), error)
         })
     }
     
@@ -836,12 +831,7 @@ import Foundation
     @discardableResult public func multipleQueriesOnline(_ queries: [Query], strategy: String?, completionHandler: @escaping CompletionHandler) -> Operation {
         return super.multipleQueries(queries, strategy: strategy, completionHandler: {
             (content, error) in
-            // Tag results as having a remote origin.
-            var taggedContent: JSONObject? = content
-            if taggedContent != nil {
-                taggedContent?[MirroredIndex.jsonKeyOrigin] = MirroredIndex.jsonValueOriginRemote
-            }
-            completionHandler(taggedContent, error)
+            completionHandler(MirroredIndex.tagAsRemote(content: content), error)
         })
     }
 
@@ -1052,12 +1042,7 @@ import Foundation
     @discardableResult public func getObjectsOnline(withIDs objectIDs: [String], attributesToRetrieve: [String]? = nil, completionHandler: @escaping CompletionHandler) -> Operation {
         return super.getObjects(withIDs: objectIDs, attributesToRetrieve: attributesToRetrieve, completionHandler: {
             (content, error) in
-            // Tag results as having a remote origin.
-            var taggedContent: JSONObject? = content
-            if taggedContent != nil {
-                taggedContent?[MirroredIndex.jsonKeyOrigin] = MirroredIndex.jsonValueOriginRemote
-            }
-            completionHandler(taggedContent, error)
+            completionHandler(MirroredIndex.tagAsRemote(content: content), error)
         })
     }
     
@@ -1080,7 +1065,8 @@ import Foundation
         let params = Query()
         params.attributesToRetrieve = attributesToRetrieve
         let searchResults = localIndex.getObjects(withIDs: objectIDs, parameters: params.build())
-        return OfflineClient.parseResponse(searchResults)
+        let (content, error) = OfflineClient.parseResponse(searchResults)
+        return (MirroredIndex.tagAsLocal(content: content), error)
     }
     
     // ----------------------------------------------------------------------

--- a/Source/Offline/MirroredIndex.swift
+++ b/Source/Offline/MirroredIndex.swift
@@ -500,7 +500,7 @@ import Foundation
     }
     
     // ----------------------------------------------------------------------
-    // MARK: - Bootstrapping
+    // MARK: - Managing offline data
     // ----------------------------------------------------------------------
     
     /// Bootstrap the local mirror with local data.
@@ -534,6 +534,16 @@ import Foundation
                 NotificationCenter.default.post(name: MirroredIndex.BootstrapDidFinishNotification, object: self, userInfo: userInfo)
             }
         })
+    }
+
+    /// Test if this index has offline data on disk.
+    ///
+    /// + Warning: This method is synchronous!
+    ///
+    /// - returns: `true` if data exists on disk for this index, `false` otherwise.
+    ///
+    @objc public func hasOfflineData() -> Bool {
+        return localIndex.exists()
     }
     
     // ----------------------------------------------------------------------

--- a/Source/Offline/MirroredIndex.swift
+++ b/Source/Offline/MirroredIndex.swift
@@ -175,7 +175,7 @@ import Foundation
     }
     
     /// The local index mirroring this remote index (lazy instantiated, only if mirroring is activated).
-    lazy var localIndex: LocalIndex = LocalIndex(dataDir: self.offlineClient.rootDataDir, appID: self.client.appID, indexName: self.name)
+    var localIndex: LocalIndex!
     
     /// The mirrored index settings.
     let mirrorSettings = MirrorSettings()
@@ -186,10 +186,21 @@ import Foundation
             if (mirrored) {
                 do {
                     try FileManager.default.createDirectory(atPath: self.indexDataDir, withIntermediateDirectories: true, attributes: nil)
+                    // Lazy instantiate the local index.
+                    self.synchronized {
+                        if (self.localIndex == nil) {
+                            self.localIndex = LocalIndex(dataDir: self.offlineClient.rootDataDir, appID: self.client.appID, indexName: self.name)
+                        }
+                    }
                 } catch _ {
                     // Ignore
                 }
                 mirrorSettings.load(self.mirrorSettingsFilePath)
+            } else {
+                // Release the local index.
+                self.synchronized {
+                    self.localIndex = nil
+                }
             }
         }
     }

--- a/Source/Offline/MirroredIndex.swift
+++ b/Source/Offline/MirroredIndex.swift
@@ -1018,7 +1018,7 @@ import Foundation
     /// Get several objects from this index, optionally restricting the retrieved content.
     /// Same semantics as `Index.getObjects(withIDs:attributesToRetrieve:completionHandler:)`.
     ///
-    @objc @discardableResult override public func getObjects(withIDs objectIDs: [String], attributesToRetrieve: [String]? = nil, completionHandler: @escaping CompletionHandler) -> Operation {
+    @objc @discardableResult override public func getObjects(withIDs objectIDs: [String], attributesToRetrieve: [String]?, completionHandler: @escaping CompletionHandler) -> Operation {
         if (!mirrored) {
             return super.getObjects(withIDs: objectIDs, attributesToRetrieve: attributesToRetrieve, completionHandler: completionHandler)
         } else {

--- a/Source/Offline/MirroredIndex.swift
+++ b/Source/Offline/MirroredIndex.swift
@@ -1036,4 +1036,30 @@ import Foundation
     /// This notification is sent both for syncs or manual builds.
     ///
     @objc public static let BuildDidFinishNotification = Notification.Name("AlgoliaSearch.MirroredIndex.BuildDidFinishNotification")
+    
+    // ----------------------------------------------------------------------
+    // MARK: - Utils
+    // ----------------------------------------------------------------------
+
+    /// Tag some content as having remote origin.
+    ///
+    /// - parameter content: The content to tag. For convenience purposes, `nil` is allowed.
+    /// - returns: The tagged content, or `nil` if `content` was `nil`.
+    ///
+    private static func tagAsRemote(content: JSONObject?) -> JSONObject? {
+        var taggedContent: JSONObject? = content
+        taggedContent?[MirroredIndex.jsonKeyOrigin] = MirroredIndex.jsonValueOriginRemote
+        return taggedContent
+    }
+
+    /// Tag some content as having local origin.
+    ///
+    /// - parameter content: The content to tag. For convenience purposes, `nil` is allowed.
+    /// - returns: The tagged content, or `nil` if `content` was `nil`.
+    ///
+    private static func tagAsLocal(content: JSONObject?) -> JSONObject? {
+        var taggedContent: JSONObject? = content
+        taggedContent?[MirroredIndex.jsonKeyOrigin] = MirroredIndex.jsonValueOriginLocal
+        return taggedContent
+    }
 }

--- a/Source/Offline/MirroredIndex.swift
+++ b/Source/Offline/MirroredIndex.swift
@@ -51,21 +51,20 @@ import Foundation
 
 /// An online index that can also be mirrored locally.
 ///
+/// + Note: You cannot construct this class directly. Please use `OfflineClient.index(withName:)` to obtain an
+///   instance.
+///
+/// + Note: Requires Algolia's SDK. The `OfflineClient.enableOfflineMode(...)` method must be called with a valid
+/// license key prior to calling any offline-related method.
+///
 /// When created, an instance of this class has its `mirrored` flag set to false, and behaves like a normal,
 /// online `Index`. When the `mirrored` flag is set to true, the index becomes capable of acting upon local data.
 ///
 /// + Warning: It is a programming error to call methods acting on the local data when `mirrored` is false. Doing so
 /// will result in an assertion error being raised.
 ///
-/// Native resources are lazily instantiated at the first method call requiring them. They are released when the
-/// object is released. Although the client guards against concurrent accesses, it is strongly discouraged
-/// to create more than one `MirroredIndex` instance pointing to the same index, as that would duplicate
-/// native resources.
 ///
-/// + Note: Requires Algolia's SDK. The `OfflineClient.enableOfflineMode(...)` method must be called with a valid
-/// license key prior to calling any offline-related method.
-///
-/// ### Request strategy
+/// ## Request strategy
 ///
 /// When the index is mirrored and the device is online, it becomes possible to transparently switch between online and
 /// offline requests. There is no single best strategy for that, because it depends on the use case and the current
@@ -151,6 +150,12 @@ import Foundation
 ///
 /// - **CJK segmentation** is not supported.
 ///
+///
+/// ## Resource handling
+///
+/// Native resources are lazily instantiated when `mirrored` is set to `true`. They are released when the object is
+/// released, or if `mirrored` is set to `false` again.
+///
 @objc public class MirroredIndex : Index {
     
     // ----------------------------------------------------------------------
@@ -235,6 +240,14 @@ import Foundation
     /// Error encountered by the current/last sync (if any).
     @objc public private(set) var syncError : Error?
 
+    /// Whether this index has offline data on disk.
+    ///
+    @objc public var hasOfflineData: Bool {
+        get {
+            return localIndex.exists()
+        }
+    }
+    
     // ----------------------------------------------------------------------
     // MARK: - Init
     // ----------------------------------------------------------------------
@@ -517,16 +530,8 @@ import Foundation
     }
     
     // ----------------------------------------------------------------------
-    // MARK: - Managing offline data
+    // MARK: - Manual build
     // ----------------------------------------------------------------------
-    
-    /// Whether this index has offline data on disk.
-    ///
-    @objc public var hasOfflineData: Bool {
-        get {
-            return localIndex.exists()
-        }
-    }
     
     /// Replace the local mirror with local data.
     ///

--- a/Source/Offline/OfflineIndex.swift
+++ b/Source/Offline/OfflineIndex.swift
@@ -54,6 +54,9 @@ public struct IOError: CustomNSError {
 /// + Note: You cannot construct this class directly. Please use `OfflineClient.offlineIndex(withName:)` to obtain an
 ///   instance.
 ///
+/// + Note: Requires Algolia Offline Core. `OfflineClient.enableOfflineMode(...)` must be called with a valid license
+///   key prior to calling any offline-related method.
+///
 ///
 /// ## Reading
 ///
@@ -71,7 +74,7 @@ public struct IOError: CustomNSError {
 ///
 /// - Populate the transaction: call the various write methods on the `WriteTransaction` class.
 ///
-/// - Either commit (`commit()`) or rollback (`rollback()`) the transaction.
+/// - Either `commit()` or `rollback()` the transaction.
 ///
 /// ### Synchronous vs asynchronous updates
 ///
@@ -103,8 +106,7 @@ public struct IOError: CustomNSError {
 /// - the **index settings** (one JSON file); and
 /// - the **objects** (as many JSON files as needed, each containing an array of objects)
 ///
-/// ... available as local files on disk, you can replace the index's content with that data by calling the
-/// `build(...)` method.
+/// ... available as local files on disk, you can replace the index's content with that data by calling `build(...)`.
 ///
 ///
 /// ## Caveats

--- a/Source/Offline/OfflineIndex.swift
+++ b/Source/Offline/OfflineIndex.swift
@@ -438,7 +438,7 @@ public struct IOError: CustomNSError {
         return self.multipleQueriesSync(queries, strategy: strategy?.rawValue)
     }
     
-    // MARK: - Transaction management
+    // MARK: - Write operations
     
     /// A transaction to update the index.
     ///
@@ -944,7 +944,17 @@ public struct IOError: CustomNSError {
     }
     
     // MARK: - Utils
-    
+
+    /// Test if this index has offline data on disk.
+    ///
+    /// + Warning: This method is synchronous!
+    ///
+    /// - returns: `true` if data exists on disk for this index, `false` otherwise.
+    ///
+    @objc public func hasOfflineData() -> Bool {
+        return localIndex.exists()
+    }
+
     /// Call a completion handler on the main queue.
     ///
     /// - parameter completionHandler: The completion handler to call. If `nil`, this function does nothing.

--- a/Source/Offline/OfflineIndex.swift
+++ b/Source/Offline/OfflineIndex.swift
@@ -132,7 +132,7 @@ public struct IOError: CustomNSError {
     @objc public let client: OfflineClient
 
     /// The local index (lazy instantiated).
-    lazy var localIndex: LocalIndex = LocalIndex(dataDir: self.client.rootDataDir, appID: self.client.appID, indexName: self.name)
+    var localIndex: LocalIndex
 
     /// Queue used to run transaction bodies (but not the build).
     private let transactionQueue: OperationQueue
@@ -155,6 +155,7 @@ public struct IOError: CustomNSError {
         self.name = name
         self.transactionQueue = OperationQueue()
         self.transactionQueue.maxConcurrentOperationCount = 1
+        self.localIndex = LocalIndex(dataDir: self.client.rootDataDir, appID: self.client.appID, indexName: self.name)
     }
     
     override public var description: String {

--- a/Source/Offline/OfflineIndex.swift
+++ b/Source/Offline/OfflineIndex.swift
@@ -131,7 +131,7 @@ public struct IOError: CustomNSError {
     /// API client used by this index.
     @objc public let client: OfflineClient
 
-    /// The local index (lazy instantiated).
+    /// The local index.
     var localIndex: LocalIndex
 
     /// Queue used to run transaction bodies (but not the build).
@@ -946,14 +946,12 @@ public struct IOError: CustomNSError {
     
     // MARK: - Utils
 
-    /// Test if this index has offline data on disk.
+    /// Whether this index has offline data on disk.
     ///
-    /// + Warning: This method is synchronous!
-    ///
-    /// - returns: `true` if data exists on disk for this index, `false` otherwise.
-    ///
-    @objc public func hasOfflineData() -> Bool {
-        return localIndex.exists()
+    @objc public var hasOfflineData: Bool {
+        get {
+            return localIndex.exists()
+        }
     }
 
     /// Call a completion handler on the main queue.

--- a/Source/Offline/OfflineIndex.swift
+++ b/Source/Offline/OfflineIndex.swift
@@ -849,8 +849,6 @@ public struct IOError: CustomNSError {
     
     /// Create a new write transaction.
     ///
-    /// + Warning: You cannot open parallel transactions. This method will assert if a transaction is already open.
-    ///
     @objc public func newTransaction() -> WriteTransaction {
         return WriteTransaction(index: self)
     }

--- a/Tests/IndexTests.swift
+++ b/Tests/IndexTests.swift
@@ -283,9 +283,9 @@ class IndexTests: OnlineTestCase {
                             if let error = error {
                                 XCTFail("Error during getObjects: \(error)")
                             } else {
-                                let items = content!["results"] as! [[String: String]]
-                                XCTAssertEqual(items[0]["city"]!, objects[0]["city"]! as? String, "GetObjects return the wrong object")
-                                XCTAssertEqual(items[1]["city"]!, objects[1]["city"]! as? String, "GetObjects return the wrong object")
+                                let items = content!["results"] as! [JSONObject]
+                                XCTAssertEqual(items[0]["city"] as? String, objects[0]["city"] as? String, "GetObjects return the wrong object")
+                                XCTAssertEqual(items[1]["city"] as? String, objects[1]["city"] as? String, "GetObjects return the wrong object")
                             }
                             
                             expectation.fulfill()
@@ -322,10 +322,10 @@ class IndexTests: OnlineTestCase {
                         expectation.fulfill()
                         return
                     }
-                    let items = content["results"] as! [[String: String]]
+                    let items = content["results"] as! [JSONObject]
                     XCTAssertEqual(2, items.count)
-                    XCTAssertEqual(items[0]["name"]! as String, "Snoopy")
-                    XCTAssertEqual(items[1]["name"]! as String, "Woodstock")
+                    XCTAssertEqual(items[0]["name"] as? String, "Snoopy")
+                    XCTAssertEqual(items[1]["name"] as? String, "Woodstock")
                     XCTAssertNil(items[0]["kind"])
                     XCTAssertNil(items[1]["kind"])
                     expectation.fulfill()

--- a/Tests/Offline/MirroredIndexTests.swift
+++ b/Tests/Offline/MirroredIndexTests.swift
@@ -96,7 +96,7 @@ class MirroredIndexTests: OfflineTestCase {
                     var observer: NSObjectProtocol?
                     observer = NotificationCenter.default.addObserver(forName: MirroredIndex.SyncDidFinishNotification, object: index, queue: OperationQueue.main) { (notification) in
                         NotificationCenter.default.removeObserver(observer!)
-                        let error = notification.userInfo?[MirroredIndex.syncErrorKey] as? Error
+                        let error = notification.userInfo?[MirroredIndex.errorKey] as? Error
                         completionBlock(error)
                     }
                     index.sync()
@@ -131,7 +131,7 @@ class MirroredIndexTests: OfflineTestCase {
                 var observer: NSObjectProtocol?
                 observer = NotificationCenter.default.addObserver(forName: MirroredIndex.SyncDidFinishNotification, object: index, queue: OperationQueue.main) { (notification) in
                     NotificationCenter.default.removeObserver(observer!)
-                    let error = notification.userInfo?[MirroredIndex.syncErrorKey] as? Error
+                    let error = notification.userInfo?[MirroredIndex.errorKey] as? Error
                     XCTAssertNil(error)
                     expectation_indexing.fulfill()
                 }

--- a/Tests/Offline/MirroredIndexTests.swift
+++ b/Tests/Offline/MirroredIndexTests.swift
@@ -251,6 +251,8 @@ class MirroredIndexTests: OfflineTestCase {
         }
         index.buildOffline(settingsFile: settingsFile, objectFiles: [objectFile]) {
             (content, error) in
+            XCTAssertNil(error)
+            
             // Check that offline data exists now.
             XCTAssertTrue(index.hasOfflineData)
             

--- a/Tests/Offline/MirroredIndexTests.swift
+++ b/Tests/Offline/MirroredIndexTests.swift
@@ -21,7 +21,7 @@
 //  THE SOFTWARE.
 //
 
-import AlgoliaSearch
+import AlgoliaSearchOffline
 import XCTest
 
 

--- a/Tests/Offline/MirroredIndexTests.swift
+++ b/Tests/Offline/MirroredIndexTests.swift
@@ -248,10 +248,12 @@ class MirroredIndexTests: OfflineTestCase {
             let error = notification.userInfo?[MirroredIndex.errorKey] as? Error
             XCTAssertNil(error)
             expectation_buildFinish.fulfill()
-
+        }
+        index.buildOffline(settingsFile: settingsFile, objectFiles: [objectFile]) {
+            (content, error) in
             // Check that offline data exists now.
             XCTAssertTrue(index.hasOfflineData)
-
+            
             // Search.
             let query = Query()
             query.query = "peanuts"
@@ -263,8 +265,6 @@ class MirroredIndexTests: OfflineTestCase {
                 expectation_search.fulfill()
             }
         }
-        index.buildOffline(settingsFile: settingsFile, objectFiles: [objectFile])
-
         waitForExpectations(timeout: 10, handler: nil)
     }
     

--- a/Tests/Offline/OfflineClientTests.swift
+++ b/Tests/Offline/OfflineClientTests.swift
@@ -21,7 +21,7 @@
 //  THE SOFTWARE.
 //
 
-import AlgoliaSearch
+import AlgoliaSearchOffline
 import Foundation
 import XCTest
 

--- a/Tests/Offline/OfflineIndexTests.swift
+++ b/Tests/Offline/OfflineIndexTests.swift
@@ -21,7 +21,7 @@
 //  THE SOFTWARE.
 //
 
-import AlgoliaSearch
+import AlgoliaSearchOffline
 import Foundation
 import XCTest
 

--- a/Tests/Offline/OfflineObjcBridging.m
+++ b/Tests/Offline/OfflineObjcBridging.m
@@ -23,7 +23,7 @@
 
 #import <XCTest/XCTest.h>
 
-@import AlgoliaSearch;
+@import AlgoliaSearchOffline;
 
 
 /// Verifies that all the features are accessible from Objective-C.

--- a/Tests/Offline/OfflineObjcBridging.m
+++ b/Tests/Offline/OfflineObjcBridging.m
@@ -176,7 +176,9 @@
     MirroredIndex* index = [client indexWithName:@"INDEX_NAME"];
 
     [index hasOfflineData];
-    [index buildOfflineWithSettingsFile:@"settings.json" objectFiles:@[ @"objects.json" ]];
+    [index buildOfflineWithSettingsFile:@"settings.json" objectFiles:@[ @"objects.json" ] completionHandler:^(NSDictionary<NSString*,id>* content, NSError* error) {
+        // Do nothing.
+    }];
     [index getObjectOnlineWithID:@"id" attributesToRetrieve:nil completionHandler:^(NSDictionary<NSString*,id>* content, NSError* error) {
         // Do nothing.
     }];

--- a/Tests/Offline/OfflineObjcBridging.m
+++ b/Tests/Offline/OfflineObjcBridging.m
@@ -180,6 +180,7 @@
 - (void)testMirroredIndex {
     OfflineClient* client = [[OfflineClient alloc] initWithAppID:@"APPID" apiKey:@"APIKEY"];
     MirroredIndex* index = [client indexWithName:@"INDEX_NAME"];
+    index.mirrored = YES;
 
     [index hasOfflineData];
     [index buildOfflineWithSettingsFile:@"settings.json" objectFiles:@[ @"objects.json" ] completionHandler:^(NSDictionary<NSString*,id>* content, NSError* error) {

--- a/Tests/Offline/OfflineObjcBridging.m
+++ b/Tests/Offline/OfflineObjcBridging.m
@@ -51,6 +51,8 @@
     OfflineClient* client = [[OfflineClient alloc] initWithAppID:@"APPID" apiKey:@"APIKEY"];
     [client enableOfflineModeWithLicenseKey:@"LICENSE_KEY"];
 
+    [client hasOfflineDataWithIndexName:@"name"];
+
     // Operations
     // ----------
     [client listOfflineIndexes:^(NSDictionary<NSString*,id>* content, NSError* error) {
@@ -148,6 +150,7 @@
 
     // Write operations (sync)
     // ------------------------
+    [index hasOfflineData];
     dispatch_async(dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0), ^{
         NSError* error = nil;
         WriteTransaction* transaction = [index newTransaction];
@@ -166,6 +169,13 @@
         [transaction commitSyncAndReturnError:&error];
         XCTAssertNil(error);
     });
+}
+
+- (void)testMirroredIndex {
+    OfflineClient* client = [[OfflineClient alloc] initWithAppID:@"APPID" apiKey:@"APIKEY"];
+    MirroredIndex* index = [client indexWithName:@"INDEX_NAME"];
+
+    [index hasOfflineData];
 }
 
 @end

--- a/Tests/Offline/OfflineObjcBridging.m
+++ b/Tests/Offline/OfflineObjcBridging.m
@@ -169,6 +169,12 @@
         [transaction commitSyncAndReturnError:&error];
         XCTAssertNil(error);
     });
+
+    // Manual build
+    // ------------
+    [index buildWithSettingsFile:@"settings.json" objectFiles:@[ @"objects.json" ] completionHandler:^(NSDictionary<NSString*,id>* content, NSError* error) {
+        // Do nothing.
+    }];
 }
 
 - (void)testMirroredIndex {

--- a/Tests/Offline/OfflineObjcBridging.m
+++ b/Tests/Offline/OfflineObjcBridging.m
@@ -176,6 +176,8 @@
     MirroredIndex* index = [client indexWithName:@"INDEX_NAME"];
 
     [index hasOfflineData];
+    [index bootstrapWithSettingsFile:@"settings.json" objectFiles:@[ @"objects.json" ]];
+    [index buildOfflineWithSettingsFile:@"settings.json" objectFiles:@[ @"objects.json" ]];
 }
 
 @end

--- a/Tests/Offline/OfflineObjcBridging.m
+++ b/Tests/Offline/OfflineObjcBridging.m
@@ -177,6 +177,18 @@
 
     [index hasOfflineData];
     [index buildOfflineWithSettingsFile:@"settings.json" objectFiles:@[ @"objects.json" ]];
+    [index getObjectOnlineWithID:@"id" attributesToRetrieve:nil completionHandler:^(NSDictionary<NSString*,id>* content, NSError* error) {
+        // Do nothing.
+    }];
+    [index getObjectsOnlineWithIDs:@[ @"id" ] attributesToRetrieve:nil completionHandler:^(NSDictionary<NSString*,id>* content, NSError* error) {
+        // Do nothing.
+    }];
+    [index getObjectOfflineWithID:@"id" attributesToRetrieve:nil completionHandler:^(NSDictionary<NSString*,id>* content, NSError* error) {
+        // Do nothing.
+    }];
+    [index getObjectsOfflineWithIDs:@[ @"id" ] attributesToRetrieve:nil completionHandler:^(NSDictionary<NSString*,id>* content, NSError* error) {
+        // Do nothing.
+    }];
 }
 
 @end

--- a/Tests/Offline/OfflineObjcBridging.m
+++ b/Tests/Offline/OfflineObjcBridging.m
@@ -176,7 +176,6 @@
     MirroredIndex* index = [client indexWithName:@"INDEX_NAME"];
 
     [index hasOfflineData];
-    [index bootstrapWithSettingsFile:@"settings.json" objectFiles:@[ @"objects.json" ]];
     [index buildOfflineWithSettingsFile:@"settings.json" objectFiles:@[ @"objects.json" ]];
 }
 

--- a/Tests/Offline/OfflineTestCase.swift
+++ b/Tests/Offline/OfflineTestCase.swift
@@ -21,7 +21,7 @@
 //  THE SOFTWARE.
 //
 
-import AlgoliaSearch
+import AlgoliaSearchOffline
 import Foundation
 import XCTest
 

--- a/Tests/Offline/objects.json
+++ b/Tests/Offline/objects.json
@@ -1,0 +1,37 @@
+[
+    {
+        "objectID": "1",
+        "name": "Snoopy",
+        "kind": [ "dog", "animal" ],
+        "born": 1967,
+        "series": "Peanuts"
+    },
+    {
+        "objectID": "2",
+        "name": "Woodstock",
+        "kind": ["bird", "animal" ],
+        "born": 1970,
+        "series": "Peanuts"
+    },
+    {
+        "objectID": "3",
+        "name": "Charlie Brown",
+        "kind": [ "human" ],
+        "born": 1950,
+        "series": "Peanuts"
+    },
+    {
+        "objectID": "4",
+        "name": "Hobbes",
+        "kind": [ "tiger", "animal", "teddy" ],
+        "born": 1985,
+        "series": "Calvin & Hobbes"
+    },
+    {
+        "objectID": "5",
+        "name": "Calvin",
+        "kind": [ "human" ],
+        "born": 1985,
+        "series": "Calvin & Hobbes"
+    }
+]

--- a/Tests/Offline/settings.json
+++ b/Tests/Offline/settings.json
@@ -1,0 +1,10 @@
+{
+    "attributesToIndex": [
+        "name",
+        "kind",
+        "series"
+    ],
+    "attributesForFaceting": [
+        "kind"
+    ]
+}

--- a/offline.jazzy.yaml
+++ b/offline.jazzy.yaml
@@ -1,5 +1,6 @@
 # In the case of the offline flavor, the Xcode project is not standalone: we need the Cocoapods-generated workspace
 # to draw dependencies.
+module: AlgoliaSearchOffline
 xcodebuild_arguments:
     - -workspace
     - AlgoliaSearch.xcworkspace

--- a/tools/make-doc.sh
+++ b/tools/make-doc.sh
@@ -41,12 +41,18 @@ rm -rf "$DST_DIR"/*
 
 # Generate the documentations with [Jazzy](https://github.com/realm/jazzy).
 cd "$PROJECT_ROOT"
+
 # Online flavor -> root directory.
 echo "# Generating online flavor"
 jazzy --config .jazzy.yaml
+
 # Offline flavor -> `offline` subdirectory.
 echo "# Generating offline flavor"
 jazzy --config offline.jazzy.yaml
+# NOTE: The offline flavor will be generated with a module name set to "AlgoliaSearchOffline", as in the Xcode project.
+# But we wish to document it as "AlgoliaSearch" (same module name as the online client) because this is what is used
+# in the Cocoapods spec. => Patch the generated files.
+find "$DST_DIR/offline" -type f -exec sed -i '' -E 's/AlgoliaSearchOffline/AlgoliaSearch/g' {} \;
 
 cp "$PROJECT_ROOT/LICENSE" "$DST_DIR/LICENSE.md"
 


### PR DESCRIPTION
- Manually build a `MirroredIndex` or an `OfflineIndex` from local files. Combined with a new `hasOfflineData` property, this allows **bootstrapping** a mirrored index before the first sync.

- Get individual objects directly from the local mirror of a `MirroredIndex`, or use the same fallback policy as search.
