### PR TITLE
Support offline search for facet values

### DIFF
--- a/AlgoliaSearch-Offline-Swift.podspec
+++ b/AlgoliaSearch-Offline-Swift.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
 
     s.ios.deployment_target = '8.0'
 
-    s.dependency 'AlgoliaSearchOfflineCore-iOS', '~> 1.0'
+    s.dependency 'AlgoliaSearchOfflineCore-iOS', '~> 1.1'
 
     # Activate Core-dependent code.
     # WARNING: Specifying the preprocessor macro is not enough; it must be added to Swift flags as well.

--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@
 use_frameworks!
 
 def common_deps
-    pod 'AlgoliaSearchOfflineCore-iOS', '~> 1.0'
+    pod 'AlgoliaSearchOfflineCore-iOS', '~> 1.1'
 end
 
 target "AlgoliaSearch-Offline-iOS" do

--- a/Source/Offline/OfflineIndex.swift
+++ b/Source/Offline/OfflineIndex.swift
@@ -464,6 +464,28 @@ public struct IOError: CustomNSError {
         return self.multipleQueriesSync(queries, strategy: strategy?.rawValue)
     }
     
+    /// Search for facet values.
+    /// Same parameters as `Index.searchForFacetValues(...)`.
+    ///
+    @discardableResult
+    @objc(searchForFacetValuesOf:matching:query:completionHandler:)
+    public func searchForFacetValues(of facetName: String, matching text: String, query: Query? = nil, completionHandler: @escaping CompletionHandler) -> Operation {
+        let queryCopy = query != nil ? Query(copy: query!) : nil
+        let operation = BlockOperation() {
+            let (content, error) = self.searchForFacetValuesSync(of: facetName, matching: text, query: queryCopy)
+            self.callCompletionHandler(completionHandler, content: content, error: error)
+        }
+        client.searchQueue.addOperation(operation)
+        return operation
+    }
+
+    /// Search for facet values (synchronous version).
+    ///
+    private func searchForFacetValuesSync(of facetName: String, matching text: String, query: Query? = nil) -> APIResponse {
+        let searchResults = self.localIndex.searchForFacetValues(of: facetName, matching: text, parameters: query?.build())
+        return OfflineClient.parseResponse(searchResults)
+    }
+
     // ----------------------------------------------------------------------
     // MARK: - Write operations
     // ----------------------------------------------------------------------

--- a/Tests/Offline/OfflineTestCase.swift
+++ b/Tests/Offline/OfflineTestCase.swift
@@ -50,6 +50,11 @@ class OfflineTestCase: XCTestCase {
         super.tearDown()
     }
     
+    let settings: [String: Any] = [
+        "searchableAttributes": ["name", "kind", "series"],
+        "attributesForFaceting": ["searchable(series)"]
+    ]
+    
     let objects: [String: JSONObject] = [
         "snoopy": [
             "objectID": "1",


### PR DESCRIPTION
Implement offline search for facet values, just like for regular search:

- on `MirroredIndex` with request strategy
- on `OfflineIndex` for pure offline request

Requires Offline Core 1.1.0, which is out now.