### PR TITLE
Add an option to choose a custom queue for completion handlers

### DIFF
--- a/Source/AbstractClient.swift
+++ b/Source/AbstractClient.swift
@@ -171,11 +171,19 @@ internal struct HostStatus {
     // NOTE: Not constant only for the sake of mocking during unit tests.
     var session: URLSession
     
-    /// Operation queue used to keep track of requests.
+    /// Operation queue used to keep track of network requests.
     /// `Request` instances are inherently asynchronous, since they are merely wrappers around `NSURLSessionTask`.
-    /// The sole purpose of the queue is to retain them for the duration of their execution!
+    /// The sole purpose of this queue is to retain them for the duration of their execution!
     ///
-    let requestQueue: OperationQueue
+    /// + Warning: This queue must allow enough parallel executions to avoid stalling when the response time is high.
+    ///   Because it's merely a memory management tool, we don't want it to be the limiting factor; `URLSession`
+    ///   already has its own logic of connection pooling.
+    ///
+    let onlineRequestQueue: OperationQueue
+    
+    /// Maximum number of concurrent requests we allow per connection.
+    /// This setting is used to dimension `onlineRequestQueue`.
+    private let maxConcurrentRequestCountPerConnection = 4
     
     /// Dispatch queue used to run completion handlers.
     internal var completionQueue = DispatchQueue.main
@@ -220,8 +228,9 @@ internal struct HostStatus {
         configuration.httpAdditionalHeaders = fixedHTTPHeaders
         session = Foundation.URLSession(configuration: configuration)
         
-        requestQueue = OperationQueue()
-        requestQueue.maxConcurrentOperationCount = 8
+        onlineRequestQueue = OperationQueue()
+        onlineRequestQueue.name = "AlgoliaSearch online requests"
+        onlineRequestQueue.maxConcurrentOperationCount = configuration.httpMaximumConnectionsPerHost * maxConcurrentRequestCountPerConnection
         
         super.init()
         
@@ -301,7 +310,7 @@ internal struct HostStatus {
     func performHTTPQuery(path: String, method: HTTPMethod, body: JSONObject?, hostnames: [String], isSearchQuery: Bool = false, completionHandler: CompletionHandler? = nil) -> Operation {
         let request = newRequest(method: method, path: path, body: body, hostnames: hostnames, isSearchQuery: isSearchQuery, completion: completionHandler)
         request.completionQueue = self.completionQueue
-        requestQueue.addOperation(request)
+        onlineRequestQueue.addOperation(request)
         return request
     }
     

--- a/Source/AbstractClient.swift
+++ b/Source/AbstractClient.swift
@@ -185,8 +185,15 @@ internal struct HostStatus {
     /// This setting is used to dimension `onlineRequestQueue`.
     private let maxConcurrentRequestCountPerConnection = 4
     
-    /// Dispatch queue used to run completion handlers.
-    internal var completionQueue = DispatchQueue.main
+    /// Operation queue used to run completion handlers.
+    /// Default = main queue.
+    ///
+    /// + Note: This will affect completion handlers of all methods on all indices attached to this client.
+    ///
+    /// + Warning: The queue is not retained by the client. You must ensure that it remains valid for the lifetime of
+    ///   the client.
+    ///
+    @objc public weak var completionQueue = OperationQueue.main
     
     // MARK: Constant
     

--- a/Source/Client.swift
+++ b/Source/Client.swift
@@ -48,6 +48,11 @@ import Foundation
     ///
     var indices: NSMapTable<NSString, AnyObject> = NSMapTable(keyOptions: [.strongMemory], valueOptions: [.weakMemory])
     
+    /// Queue for purely in-memory operations (no I/Os).
+    /// Typically used for aggregate, concurrent operations.
+    ///
+    internal var inMemoryQueue: OperationQueue = OperationQueue()
+    
     // MARK: Initialization
     
     /// Create a new Algolia Search client.
@@ -72,6 +77,7 @@ import Foundation
         let readHosts = [ "\(appID)-dsn.algolia.net" ] + fallbackHosts
         let writeHosts = [ "\(appID).algolia.net" ] + fallbackHosts
         super.init(appID: appID, apiKey: apiKey, readHosts: readHosts, writeHosts: writeHosts)
+        inMemoryQueue.maxConcurrentOperationCount = onlineRequestQueue.maxConcurrentOperationCount
     }
 
     /// Obtain a proxy to an Algolia index (no server call required by this method).

--- a/Source/Index.swift
+++ b/Source/Index.swift
@@ -331,12 +331,11 @@ import Foundation
         let cacheKey = "\(path)_body_\(request)"
         if let content = searchCache?.objectForKey(cacheKey) {
             // We *have* to return something, so we create a simple operation.
-            // Note that its execution will be deferred until the next iteration of the main run loop.
             let operation = AsyncBlockOperation(completionHandler: completionHandler) {
                 return (content, nil)
             }
             operation.completionQueue = client.completionQueue
-            OperationQueue.main.addOperation(operation)
+            client.inMemoryQueue.addOperation(operation)
             return operation
         }
         // Otherwise, run an online query.
@@ -487,7 +486,7 @@ import Foundation
     @objc
     @discardableResult public func waitTask(withID taskID: Int, completionHandler: @escaping CompletionHandler) -> Operation {
         let operation = WaitOperation(index: self, taskID: taskID, completionHandler: completionHandler)
-        operation.start()
+        client.inMemoryQueue.addOperation(operation)
         return operation
     }
     
@@ -553,7 +552,7 @@ import Foundation
     @objc
     @discardableResult public func deleteByQuery(_ query: Query, completionHandler: CompletionHandler? = nil) -> Operation {
         let operation = DeleteByQueryOperation(index: self, query: query, completionHandler: completionHandler)
-        operation.start()
+        client.inMemoryQueue.addOperation(operation)
         return operation
     }
     

--- a/Source/Offline/MirroredIndex.swift
+++ b/Source/Offline/MirroredIndex.swift
@@ -349,7 +349,7 @@ import Foundation
     @objc
     public func sync() {
         assert(self.mirrored, "Mirroring not activated on this index")
-        offlineClient.buildQueue.addOperation() {
+        offlineClient.offlineBuildQueue.addOperation() {
             self._sync()
         }
     }
@@ -363,7 +363,7 @@ import Foundation
     public func syncIfNeeded() {
         assert(self.mirrored, "Mirroring not activated on this index")
         if self.isSyncDelayExpired() || self.isMirrorSettingsDirty() {
-            offlineClient.buildQueue.addOperation() {
+            offlineClient.offlineBuildQueue.addOperation() {
                 self._sync()
             }
         }
@@ -396,7 +396,7 @@ import Foundation
     ///
     private func _sync() {
         assert(!Thread.isMainThread) // make sure it's run in the background
-        assert(OperationQueue.current == offlineClient.buildQueue) // ensure serial calls
+        assert(OperationQueue.current == offlineClient.offlineBuildQueue) // ensure serial calls
         assert(!self.dataSelectionQueries.isEmpty)
 
         // If already syncing, abort.
@@ -440,7 +440,7 @@ import Foundation
                 }
             }
         }
-        offlineClient.buildQueue.addOperation(settingsOperation)
+        offlineClient.offlineBuildQueue.addOperation(settingsOperation)
         
         // Task: build the index using the downloaded files.
         buildIndexOperation = BlockOperation() {
@@ -468,7 +468,7 @@ import Foundation
         }
         
         // Finally add the build index operation to the queue, now that dependencies are set up.
-        offlineClient.buildQueue.addOperation(buildIndexOperation!)
+        offlineClient.offlineBuildQueue.addOperation(buildIndexOperation!)
     }
     
     // Auxiliary function, called:
@@ -510,7 +510,7 @@ import Foundation
                 }
             }
         }
-        offlineClient.buildQueue.addOperation(operation)
+        offlineClient.offlineBuildQueue.addOperation(operation)
         buildIndexOperation!.addDependency(operation)
     }
 
@@ -519,7 +519,7 @@ import Foundation
     /// WARNING: Calls to this method must be synchronized by the caller.
     ///
     private func _syncFinished() {
-        assert(OperationQueue.current == offlineClient.buildQueue) // ensure serial calls
+        assert(OperationQueue.current == offlineClient.offlineBuildQueue) // ensure serial calls
 
         // Clean-up.
         do {
@@ -567,7 +567,7 @@ import Foundation
             return self._buildOffline(settingsFile: settingsFile, objectFiles: objectFiles)
         }
         operation.completionQueue = client.completionQueue
-        offlineClient.buildQueue.addOperation(operation)
+        offlineClient.offlineBuildQueue.addOperation(operation)
         return operation
     }
 
@@ -581,7 +581,7 @@ import Foundation
     ///
     private func _buildOffline(settingsFile: String, objectFiles: [String]) -> (JSONObject?, Error?) {
         assert(!Thread.isMainThread) // make sure it's run in the background
-        assert(OperationQueue.current == offlineClient.buildQueue) // ensure serial calls
+        assert(OperationQueue.current == offlineClient.offlineBuildQueue) // ensure serial calls
         var content: JSONObject? = nil
         var error: Error? = nil
         // Notify observers.
@@ -803,7 +803,7 @@ import Foundation
             return self._searchOffline(queryCopy)
         }
         operation.completionQueue = client.completionQueue
-        self.offlineClient.searchQueue.addOperation(operation)
+        self.offlineClient.offlineSearchQueue.addOperation(operation)
         return operation
     }
 
@@ -892,7 +892,7 @@ import Foundation
             return self._multipleQueriesOffline(queries, strategy: strategy)
         }
         operation.completionQueue = client.completionQueue
-        self.offlineClient.searchQueue.addOperation(operation)
+        self.offlineClient.offlineSearchQueue.addOperation(operation)
         return operation
     }
     
@@ -931,7 +931,7 @@ import Foundation
             return self._browseMirror(query: queryCopy)
         }
         operation.completionQueue = client.completionQueue
-        self.offlineClient.searchQueue.addOperation(operation)
+        self.offlineClient.offlineSearchQueue.addOperation(operation)
         return operation
     }
 
@@ -946,7 +946,7 @@ import Foundation
             return self._browseMirror(query: query)
         }
         operation.completionQueue = client.completionQueue
-        self.offlineClient.searchQueue.addOperation(operation)
+        self.offlineClient.offlineSearchQueue.addOperation(operation)
         return operation
     }
 
@@ -1011,7 +1011,7 @@ import Foundation
             return self._getObjectOffline(withID: objectID, attributesToRetrieve: attributesToRetrieve)
         }
         operation.completionQueue = client.completionQueue
-        self.offlineClient.searchQueue.addOperation(operation)
+        self.offlineClient.offlineSearchQueue.addOperation(operation)
         return operation
     }
     
@@ -1083,7 +1083,7 @@ import Foundation
             return self._getObjectsOffline(withIDs: objectIDs, attributesToRetrieve: attributesToRetrieve)
         }
         operation.completionQueue = client.completionQueue
-        self.offlineClient.searchQueue.addOperation(operation)
+        self.offlineClient.offlineSearchQueue.addOperation(operation)
         return operation
     }
     
@@ -1161,7 +1161,7 @@ import Foundation
             return self._searchForFacetValuesOffline(of: facetName, matching: text, query: query)
         }
         operation.completionQueue = client.completionQueue
-        self.offlineClient.searchQueue.addOperation(operation)
+        self.offlineClient.offlineSearchQueue.addOperation(operation)
         return operation
     }
     

--- a/Source/Offline/OfflineClient.swift
+++ b/Source/Offline/OfflineClient.swift
@@ -56,14 +56,14 @@ typealias APIResponse = (content: JSONObject?, error: Error?)
     // resource consumption by the SDK.
     
     /// Queue used to build local indices in the background.
-    let buildQueue = OperationQueue()
+    let offlineBuildQueue = OperationQueue()
     
     /// Queue used to search local indices in the background.
-    let searchQueue = OperationQueue()
+    let offlineSearchQueue = OperationQueue()
     
     /// Queue for mixed online/offline operations.
     ///
-    /// + Note: We could use `Client.requestQueue`, but since mixed operations are essentially aggregations of
+    /// + Note: We could use `Client.onlineRequestQueue`, but since mixed operations are essentially aggregations of
     ///   individual operations, we wish to avoid deadlocks.
     ///
     let mixedRequestQueue = OperationQueue()
@@ -81,15 +81,15 @@ typealias APIResponse = (content: JSONObject?, error: Error?)
     /// - parameter apiKey: a valid API key for the service
     ///
     @objc public override init(appID: String, apiKey: String) {
-        buildQueue.name = "AlgoliaSearch-Build"
-        buildQueue.maxConcurrentOperationCount = 1
-        searchQueue.name = "AlgoliaSearch-Search"
-        searchQueue.maxConcurrentOperationCount = 1
-        mixedRequestQueue.name = "AlgoliaSearch-Mixed"
+        offlineBuildQueue.name = "AlgoliaSearch offline build"
+        offlineBuildQueue.maxConcurrentOperationCount = 1
+        offlineSearchQueue.name = "AlgoliaSearch offline search"
+        offlineSearchQueue.maxConcurrentOperationCount = 1
+        mixedRequestQueue.name = "AlgoliaSearch mixed requests"
         rootDataDir = NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true).first! + "/algolia"
         tmpDir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("algolia").path
         super.init(appID: appID, apiKey: apiKey)
-        mixedRequestQueue.maxConcurrentOperationCount = super.requestQueue.maxConcurrentOperationCount
+        mixedRequestQueue.maxConcurrentOperationCount = super.onlineRequestQueue.maxConcurrentOperationCount
         userAgents.append(LibraryVersion(name: "AlgoliaSearchOfflineCore-iOS", version: sdk.versionString))
     }
     
@@ -200,7 +200,7 @@ typealias APIResponse = (content: JSONObject?, error: Error?)
             let (content, error) = self.listOfflineIndexesSync()
             self.callCompletionHandler(completionHandler, content: content, error: error)
         }
-        searchQueue.addOperation(operation)
+        offlineSearchQueue.addOperation(operation)
         return operation
     }
     
@@ -249,7 +249,7 @@ typealias APIResponse = (content: JSONObject?, error: Error?)
             let (content, error) = self.deleteOfflineIndexSync(withName: indexName)
             self.callCompletionHandler(completionHandler, content: content, error: error)
         }
-        buildQueue.addOperation(operation)
+        offlineBuildQueue.addOperation(operation)
         return operation
     }
     
@@ -289,7 +289,7 @@ typealias APIResponse = (content: JSONObject?, error: Error?)
             let (content, error) = self.moveOfflineIndexSync(from: srcIndexName, to: dstIndexName)
             self.callCompletionHandler(completionHandler, content: content, error: error)
         }
-        buildQueue.addOperation(operation)
+        offlineBuildQueue.addOperation(operation)
         return operation
     }
     

--- a/Source/Offline/OfflineClient.swift
+++ b/Source/Offline/OfflineClient.swift
@@ -353,7 +353,7 @@ typealias APIResponse = (content: JSONObject?, error: Error?)
         return (content: content, error: error)
     }
     
-    /// Call a completion handler on the main queue.
+    /// Call a completion handler on the completion queue.
     ///
     /// - parameter completionHandler: The completion handler to call. If `nil`, this function does nothing.
     /// - parameter content: The content to pass as a first argument to the completion handler.
@@ -361,7 +361,7 @@ typealias APIResponse = (content: JSONObject?, error: Error?)
     ///
     internal func callCompletionHandler(_ completionHandler: CompletionHandler?, content: JSONObject?, error: Error?) {
         if let completionHandler = completionHandler {
-            DispatchQueue.main.async {
+            completionQueue!.addOperation {
                 completionHandler(content, error)
             }
         }

--- a/Source/Offline/OfflineIndex.swift
+++ b/Source/Offline/OfflineIndex.swift
@@ -1054,7 +1054,7 @@ public struct IOError: CustomNSError {
     private func callCompletionHandler(_ completionHandler: CompletionHandler?, content: JSONObject?, error: Error?) {
         // TODO: Factorize with `OfflineClient`.
         if let completionHandler = completionHandler {
-            DispatchQueue.main.async {
+            client.completionQueue!.addOperation {
                 completionHandler(content, error)
             }
         }

--- a/Source/Offline/OfflineIndex.swift
+++ b/Source/Offline/OfflineIndex.swift
@@ -217,7 +217,7 @@ public struct IOError: CustomNSError {
             let (content, error) = self.getObjectSync(withID: objectID, attributesToRetrieve: attributesToRetrieve)
             self.callCompletionHandler(completionHandler, content: content, error: error)
         }
-        client.searchQueue.addOperation(operation)
+        client.offlineSearchQueue.addOperation(operation)
         return operation
     }
     
@@ -282,7 +282,7 @@ public struct IOError: CustomNSError {
             let (content, error) = self.getObjectsSync(withIDs: objectIDs, attributesToRetrieve: attributesToRetrieve)
             self.callCompletionHandler(completionHandler, content: content, error: error)
         }
-        client.searchQueue.addOperation(operation)
+        client.offlineSearchQueue.addOperation(operation)
         return operation
     }
     
@@ -312,7 +312,7 @@ public struct IOError: CustomNSError {
             let (content, error) = self.searchSync(Query(copy: query))
             self.callCompletionHandler(completionHandler, content: content, error: error)
         }
-        client.searchQueue.addOperation(operation)
+        client.offlineSearchQueue.addOperation(operation)
         return operation
     }
 
@@ -338,7 +338,7 @@ public struct IOError: CustomNSError {
             let (content, error) = self.getSettingsSync()
             self.callCompletionHandler(completionHandler, content: content, error: error)
         }
-        client.searchQueue.addOperation(operation)
+        client.offlineSearchQueue.addOperation(operation)
         return operation
     }
     
@@ -365,7 +365,7 @@ public struct IOError: CustomNSError {
             let (content, error) = self.browseSync(query: Query(copy: query))
             self.callCompletionHandler(completionHandler, content: content, error: error)
         }
-        client.searchQueue.addOperation(operation)
+        client.offlineSearchQueue.addOperation(operation)
         return operation
     }
     
@@ -395,7 +395,7 @@ public struct IOError: CustomNSError {
             let (content, error) = self.browseSync(from: cursor)
             self.callCompletionHandler(completionHandler, content: content, error: error)
         }
-        client.searchQueue.addOperation(operation)
+        client.offlineSearchQueue.addOperation(operation)
         return operation
     }
 
@@ -425,7 +425,7 @@ public struct IOError: CustomNSError {
             let (content, error) = self.multipleQueriesSync(queries, strategy: strategy)
             self.callCompletionHandler(completionHandler, content: content, error: error)
         }
-        client.searchQueue.addOperation(operation)
+        client.offlineSearchQueue.addOperation(operation)
         return operation
     }
 
@@ -475,7 +475,7 @@ public struct IOError: CustomNSError {
             let (content, error) = self.searchForFacetValuesSync(of: facetName, matching: text, query: queryCopy)
             self.callCompletionHandler(completionHandler, content: content, error: error)
         }
-        client.searchQueue.addOperation(operation)
+        client.offlineSearchQueue.addOperation(operation)
         return operation
     }
 
@@ -830,7 +830,7 @@ public struct IOError: CustomNSError {
                     error = HTTPError(statusCode: statusCode)
                 }
             }
-            index.client.buildQueue.addOperation(buildOperation)
+            index.client.offlineBuildQueue.addOperation(buildOperation)
             buildOperation.waitUntilFinished()
             if error != nil {
                 throw error!
@@ -925,7 +925,7 @@ public struct IOError: CustomNSError {
             return self._build(settingsFile: settingsFile, objectFiles: objectFiles)
         }
         operation.completionQueue = client.completionQueue
-        client.buildQueue.addOperation(operation)
+        client.offlineBuildQueue.addOperation(operation)
         return operation
     }
     
@@ -939,7 +939,7 @@ public struct IOError: CustomNSError {
     ///
     private func _build(settingsFile: String, objectFiles: [String]) -> (JSONObject?, Error?) {
         assert(!Thread.isMainThread) // make sure it's run in the background
-        assert(OperationQueue.current == client.buildQueue) // ensure serial calls
+        assert(OperationQueue.current == client.offlineBuildQueue) // ensure serial calls
 
         // Build the index.
         let status = self.localIndex.build(settingsFile: settingsFile, objectFiles: objectFiles, clearIndex: true, deletedObjectIDs: nil)

--- a/Tests/ClientTests.swift
+++ b/Tests/ClientTests.swift
@@ -487,4 +487,22 @@ class ClientTests: OnlineTestCase {
         }
         self.waitForExpectations(timeout: expectationTimeout, handler: nil)
     }
+    
+    /// Test that the completion queue is used.
+    ///
+    func testCompletionQueue() {
+        let expectation = self.expectation(description: #function)
+        let operationQueue = OperationQueue()
+        self.client.listIndexes { (content, error) in
+            XCTAssert(OperationQueue.current == OperationQueue.main)
+            
+            self.client.completionQueue = operationQueue
+            self.client.listIndexes { (content, error) in
+                XCTAssert(OperationQueue.current != OperationQueue.main)
+                XCTAssert(OperationQueue.current == operationQueue)
+                expectation.fulfill()
+            }
+        }
+        self.waitForExpectations(timeout: expectationTimeout, handler: nil)
+    }
 }

--- a/Tests/ObjectiveCBridging.m
+++ b/Tests/ObjectiveCBridging.m
@@ -153,6 +153,9 @@
     [client setHosts:@[ @"nowhere.net", @"nobody.com", @"never.org" ]];
     client.hostStatusTimeout = [Client defaultHostStatusTimeout];
 
+    // Completion queue.
+    client.completionQueue = NSOperationQueue.mainQueue;
+    
     // Operations
     // ----------
     [client listIndexes:^(NSDictionary<NSString*,id>* content, NSError* error) {


### PR DESCRIPTION
By default, the main queue is used.

Fixes #69.
