### PR TITLE
Per-request options

### DIFF
--- a/AlgoliaSearch.xcodeproj/project.pbxproj
+++ b/AlgoliaSearch.xcodeproj/project.pbxproj
@@ -117,6 +117,11 @@
 		BC72244F1D9C137B00B56908 /* OnlineTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC72244C1D9C137B00B56908 /* OnlineTestCase.swift */; };
 		BC85EA701D82C8C3009E9E7D /* ObjectiveCBridging.m in Sources */ = {isa = PBXBuildFile; fileRef = BC582C5C1D82B453007B815A /* ObjectiveCBridging.m */; };
 		BC85EA711D82C8C4009E9E7D /* ObjectiveCBridging.m in Sources */ = {isa = PBXBuildFile; fileRef = BC582C5C1D82B453007B815A /* ObjectiveCBridging.m */; };
+		BCC83C3E1F0E76BF002CD846 /* RequestOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCC83C3D1F0E76BF002CD846 /* RequestOptions.swift */; };
+		BCC83C3F1F0E76BF002CD846 /* RequestOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCC83C3D1F0E76BF002CD846 /* RequestOptions.swift */; };
+		BCC83C401F0E76BF002CD846 /* RequestOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCC83C3D1F0E76BF002CD846 /* RequestOptions.swift */; };
+		BCC83C411F0E76BF002CD846 /* RequestOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCC83C3D1F0E76BF002CD846 /* RequestOptions.swift */; };
+		BCC83C421F0E76BF002CD846 /* RequestOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCC83C3D1F0E76BF002CD846 /* RequestOptions.swift */; };
 		BCD1F5541CC61C8D0006E227 /* AlgoliaSearch.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BCD1F54A1CC61C8D0006E227 /* AlgoliaSearch.framework */; };
 		BCD1F5611CC61CFE0006E227 /* AsyncOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC4A7F381CB5308100AF1DCB /* AsyncOperation.swift */; };
 		BCD1F5621CC61D020006E227 /* Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D67400E1B4AA22600B326EC /* Cache.swift */; };
@@ -241,6 +246,7 @@
 		BC68BC561CB69776007F9655 /* IndexQuery.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IndexQuery.swift; sourceTree = "<group>"; };
 		BC72244C1D9C137B00B56908 /* OnlineTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnlineTestCase.swift; sourceTree = "<group>"; };
 		BC85EA721D82C8FD009E9E7D /* Tests-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Tests-Bridging-Header.h"; sourceTree = "<group>"; };
+		BCC83C3D1F0E76BF002CD846 /* RequestOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestOptions.swift; sourceTree = "<group>"; };
 		BCD1F54A1CC61C8D0006E227 /* AlgoliaSearch.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AlgoliaSearch.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BCD1F5531CC61C8D0006E227 /* AlgoliaSearch tvOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "AlgoliaSearch tvOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BCD57D1E1D89947500C5DE68 /* DisjunctiveFaceting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DisjunctiveFaceting.swift; sourceTree = "<group>"; };
@@ -386,6 +392,7 @@
 				BC4DDEFB1DD11527004D9A6E /* PlacesClient.swift */,
 				BC4DDF071DD12BCC004D9A6E /* PlacesQuery.swift */,
 				5D7495A61A8E499B00B0263F /* Query.swift */,
+				BCC83C3D1F0E76BF002CD846 /* RequestOptions.swift */,
 				BC01E66C1CA43CEE0067670B /* Request.swift */,
 				BC28C4D61E5B5A0E00EFC4A0 /* Searchable.swift */,
 				BC4DDEF51DD10EBA004D9A6E /* Types.swift */,
@@ -902,6 +909,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BCC83C3E1F0E76BF002CD846 /* RequestOptions.swift in Sources */,
 				BC0A015A1C9BEDB200CD4A7C /* Error.swift in Sources */,
 				BC68BC571CB69776007F9655 /* IndexQuery.swift in Sources */,
 				5D67400F1B4AA22600B326EC /* Cache.swift in Sources */,
@@ -948,6 +956,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BCC83C3F1F0E76BF002CD846 /* RequestOptions.swift in Sources */,
 				BC0A015B1C9BEDB200CD4A7C /* Error.swift in Sources */,
 				BC68BC581CB69776007F9655 /* IndexQuery.swift in Sources */,
 				5D6740101B4AA22600B326EC /* Cache.swift in Sources */,
@@ -994,6 +1003,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BCC83C421F0E76BF002CD846 /* RequestOptions.swift in Sources */,
 				BC23A6F71D63541500DF9034 /* Error.swift in Sources */,
 				BC23A6FC1D63541500DF9034 /* Query.swift in Sources */,
 				BC23A6F51D63541500DF9034 /* Cache.swift in Sources */,
@@ -1020,6 +1030,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BCC83C411F0E76BF002CD846 /* RequestOptions.swift in Sources */,
 				BC15FAC11E01C041005E3B56 /* NetworkReachability.swift in Sources */,
 				BC4BD2821D54E48900170ECC /* Error.swift in Sources */,
 				BCD57D261D89970D00C5DE68 /* MultipleQueryEmulator.swift in Sources */,
@@ -1051,6 +1062,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BCC83C401F0E76BF002CD846 /* RequestOptions.swift in Sources */,
 				BCD1F5641CC61D090006E227 /* Error.swift in Sources */,
 				BCD1F5691CC61D1A0006E227 /* Query.swift in Sources */,
 				BCD1F5621CC61D020006E227 /* Cache.swift in Sources */,

--- a/Source/AbstractClient.swift
+++ b/Source/AbstractClient.swift
@@ -356,14 +356,27 @@ internal struct HostStatus {
     /// Create a request with this client's settings.
     func newRequest(method: HTTPMethod, path: String, urlParameters: [String: String]? = nil, body: JSONObject?, hostnames: [String], isSearchQuery: Bool = false, requestOptions: RequestOptions? = nil, completion: CompletionHandler? = nil) -> Request {
         let currentTimeout = isSearchQuery ? searchTimeout : timeout
-        // Patch the headers with the request's options, if provided.
+        // Patch the headers with the request options, if provided.
         var headers = self.headers
         if let requestOptions = requestOptions {
             for (key, value) in requestOptions.headers {
                 headers[key] = value
             }
         }
-        let request = Request(client: self, method: method, hosts: hostnames, firstHostIndex: 0, path: path, urlParameters: urlParameters, headers: headers, jsonBody: body, timeout: currentTimeout, completion:  completion)
+        // Patch the URL parameters with request options, if provided.
+        var finalURLParameters: [String: String]? = nil
+        if let urlParameters = urlParameters {
+            finalURLParameters = urlParameters
+        }
+        if let requestOptions = requestOptions {
+            if finalURLParameters == nil {
+                finalURLParameters = [:]
+            }
+            for (key, value) in requestOptions.urlParameters {
+                finalURLParameters![key] = value
+            }
+        }
+        let request = Request(client: self, method: method, hosts: hostnames, firstHostIndex: 0, path: path, urlParameters: finalURLParameters, headers: headers, jsonBody: body, timeout: currentTimeout, completion:  completion)
         return request
     }
 

--- a/Source/Client.swift
+++ b/Source/Client.swift
@@ -53,7 +53,7 @@ import Foundation
     ///
     internal var inMemoryQueue: OperationQueue = OperationQueue()
     
-    // MARK: Initialization
+    // MARK: - Initialization
     
     /// Create a new Algolia Search client.
     ///
@@ -104,26 +104,38 @@ import Foundation
 
     /// List existing indexes.
     ///
+    /// - parameter requestOptions: Request-specific options.
     /// - parameter completionHandler: Completion handler to be notified of the request's outcome.
     /// - returns: A cancellable operation.
     ///
-    @objc(listIndexes:)
-    @discardableResult public func listIndexes(completionHandler: @escaping CompletionHandler) -> Operation {
-        return performHTTPQuery(path: "1/indexes", method: .GET, body: nil, hostnames: readHosts, completionHandler: completionHandler)
+    @objc(listIndexesWithRequestOptions:completionHandler:)
+    @discardableResult public func listIndexes(requestOptions: RequestOptions? = nil, completionHandler: @escaping CompletionHandler) -> Operation {
+        return self.performHTTPQuery(path: "1/indexes", method: .GET, body: nil, hostnames: readHosts, requestOptions: requestOptions, completionHandler: completionHandler)
     }
-
+    
+    @objc(listIndexes:)
+    @discardableResult public func z_objc_listIndexes(completionHandler: @escaping CompletionHandler) -> Operation {
+        return self.listIndexes(completionHandler: completionHandler)
+    }
+        
     /// Delete an index.
     ///
     /// - parameter name: Name of the index to delete.
+    /// - parameter requestOptions: Request-specific options.
     /// - parameter completionHandler: Completion handler to be notified of the request's outcome.
     /// - returns: A cancellable operation.
     ///
-    @objc(deleteIndexWithName:completionHandler:)
-    @discardableResult public func deleteIndex(withName name: String, completionHandler: CompletionHandler? = nil) -> Operation {
+    @objc(deleteIndexWithName:requestOptions:completionHandler:)
+    @discardableResult public func deleteIndex(withName name: String, requestOptions: RequestOptions? = nil, completionHandler: CompletionHandler? = nil) -> Operation {
         let path = "1/indexes/\(name.urlEncodedPathComponent())"
-        return performHTTPQuery(path: path, method: .DELETE, body: nil, hostnames: writeHosts, completionHandler: completionHandler)
+        return self.performHTTPQuery(path: path, method: .DELETE, body: nil, hostnames: writeHosts, requestOptions: requestOptions, completionHandler: completionHandler)
     }
-
+    
+    @objc(deleteIndexWithName:completionHandler:)
+    @discardableResult public func z_objc_deleteIndex(withName name: String, completionHandler: CompletionHandler?) -> Operation {
+        return self.deleteIndex(withName: name, completionHandler: completionHandler)
+    }
+    
     /// Move an existing index.
     ///
     /// If the destination index already exists, its specific API keys will be preserved and the source index specific
@@ -131,20 +143,25 @@ import Foundation
     ///
     /// - parameter srcIndexName: Name of index to move.
     /// - parameter dstIndexName: The new index name.
+    /// - parameter requestOptions: Request-specific options.
     /// - parameter completionHandler: Completion handler to be notified of the request's outcome.
     /// - returns: A cancellable operation.
     ///
-    @objc(moveIndexFrom:to:completionHandler:)
-    @discardableResult public func moveIndex(from srcIndexName: String, to dstIndexName: String, completionHandler: CompletionHandler? = nil) -> Operation {
+    @objc(moveIndexFrom:to:requestOptions:completionHandler:)
+    @discardableResult public func moveIndex(from srcIndexName: String, to dstIndexName: String, requestOptions: RequestOptions? = nil, completionHandler: CompletionHandler? = nil) -> Operation {
         let path = "1/indexes/\(srcIndexName.urlEncodedPathComponent())/operation"
         let request = [
             "destination": dstIndexName,
             "operation": "move"
         ]
-
-        return performHTTPQuery(path: path, method: .POST, body: request as [String : Any]?, hostnames: writeHosts, completionHandler: completionHandler)
+        return self.performHTTPQuery(path: path, method: .POST, body: request as [String : Any]?, hostnames: writeHosts, requestOptions: requestOptions, completionHandler: completionHandler)
     }
-
+    
+    @objc(moveIndexFrom:to:completionHandler:)
+    @discardableResult public func z_objc_moveIndex(from srcIndexName: String, to dstIndexName: String, completionHandler: CompletionHandler?) -> Operation {
+        return self.moveIndex(from: srcIndexName, to: dstIndexName, completionHandler: completionHandler)
+    }
+    
     /// Copy an existing index.
     ///
     /// If the destination index already exists, its specific API keys will be preserved and the source index specific
@@ -152,20 +169,25 @@ import Foundation
     ///
     /// - parameter srcIndexName: Name of the index to copy.
     /// - parameter dstIndexName: The new index name.
+    /// - parameter requestOptions: Request-specific options.
     /// - parameter completionHandler: Completion handler to be notified of the request's outcome.
     /// - returns: A cancellable operation.
     ///
-    @objc(copyIndexFrom:to:completionHandler:)
-    @discardableResult public func copyIndex(from srcIndexName: String, to dstIndexName: String, completionHandler: CompletionHandler? = nil) -> Operation {
+    @objc(copyIndexFrom:to:requestOptions:completionHandler:)
+    @discardableResult public func copyIndex(from srcIndexName: String, to dstIndexName: String, requestOptions: RequestOptions? = nil, completionHandler: CompletionHandler? = nil) -> Operation {
         let path = "1/indexes/\(srcIndexName.urlEncodedPathComponent())/operation"
         let request = [
             "destination": dstIndexName,
             "operation": "copy"
         ]
-
-        return performHTTPQuery(path: path, method: .POST, body: request as [String : Any]?, hostnames: writeHosts, completionHandler: completionHandler)
+        return self.performHTTPQuery(path: path, method: .POST, body: request as [String : Any]?, hostnames: writeHosts, requestOptions: requestOptions, completionHandler: completionHandler)
     }
-
+    
+    @objc(copyIndexFrom:to:completionHandler:)
+    @discardableResult public func z_objc_copyIndex(from srcIndexName: String, to dstIndexName: String, completionHandler: CompletionHandler?) -> Operation {
+        return self.copyIndex(from: srcIndexName, to: dstIndexName, completionHandler: completionHandler)
+    }
+    
     /// Strategy when running multiple queries. See `Client.multipleQueries(...)`.
     ///
     public enum MultipleQueriesStrategy: String {
@@ -182,11 +204,12 @@ import Foundation
     ///
     /// - parameter queries: List of queries.
     /// - parameter strategy: The strategy to use.
+    /// - parameter requestOptions: Request-specific options.
     /// - parameter completionHandler: Completion handler to be notified of the request's outcome.
     /// - returns: A cancellable operation.
     ///
-    @objc(multipleQueries:strategy:completionHandler:)
-    @discardableResult public func multipleQueries(_ queries: [IndexQuery], strategy: String?, completionHandler: @escaping CompletionHandler) -> Operation {
+    @objc(multipleQueries:strategy:requestOptions:completionHandler:)
+    @discardableResult public func multipleQueries(_ queries: [IndexQuery], strategy: String?, requestOptions: RequestOptions? = nil, completionHandler: @escaping CompletionHandler) -> Operation {
         // IMPLEMENTATION NOTE: Objective-C bridgeable alternative.
         let path = "1/indexes/*/queries"
         var requests = [JSONObject]()
@@ -202,31 +225,43 @@ import Foundation
         if strategy != nil {
             request["strategy"] = strategy
         }
-        return performHTTPQuery(path: path, method: .POST, body: request, hostnames: readHosts, completionHandler: completionHandler)
+        return self.performHTTPQuery(path: path, method: .POST, body: request, hostnames: readHosts, requestOptions: requestOptions, completionHandler: completionHandler)
+    }
+    
+    @objc(multipleQueries:strategy:completionHandler:)
+    @discardableResult public func z_objc_multipleQueries(_ queries: [IndexQuery], strategy: String?, completionHandler: @escaping CompletionHandler) -> Operation {
+        return self.multipleQueries(queries, strategy: strategy, completionHandler: completionHandler)
     }
     
     /// Query multiple indexes with one API call.
     ///
     /// - parameter queries: List of queries.
     /// - parameter strategy: The strategy to use.
+    /// - parameter requestOptions: Request-specific options.
     /// - parameter completionHandler: Completion handler to be notified of the request's outcome.
     /// - returns: A cancellable operation.
     ///
-    @discardableResult public func multipleQueries(_ queries: [IndexQuery], strategy: MultipleQueriesStrategy? = nil, completionHandler: @escaping CompletionHandler) -> Operation {
+    @discardableResult public func multipleQueries(_ queries: [IndexQuery], strategy: MultipleQueriesStrategy? = nil, requestOptions: RequestOptions? = nil, completionHandler: @escaping CompletionHandler) -> Operation {
         // IMPLEMENTATION NOTE: Not Objective-C bridgeable because of enum.
-        return multipleQueries(queries, strategy: strategy?.rawValue, completionHandler: completionHandler)
+        return self.multipleQueries(queries, strategy: strategy?.rawValue, requestOptions: requestOptions, completionHandler: completionHandler)
     }
     
     /// Batch operations.
     ///
     /// - parameter operations: List of operations.
+    /// - parameter requestOptions: Request-specific options.
     /// - parameter completionHandler: Completion handler to be notified of the request's outcome.
     /// - returns: A cancellable operation.
     ///
-    @objc(batchOperations:completionHandler:)
-    @discardableResult public func batch(operations: [Any], completionHandler: CompletionHandler? = nil) -> Operation {
+    @objc(batchOperations:requestOptions:completionHandler:)
+    @discardableResult public func batch(operations: [Any], requestOptions: RequestOptions? = nil, completionHandler: CompletionHandler? = nil) -> Operation {
         let path = "1/indexes/*/batch"
         let body = ["requests": operations]
-        return performHTTPQuery(path: path, method: .POST, body: body as [String : Any]?, hostnames: writeHosts, completionHandler: completionHandler)
+        return self.performHTTPQuery(path: path, method: .POST, body: body as [String : Any]?, hostnames: writeHosts, requestOptions: requestOptions, completionHandler: completionHandler)
+    }
+    
+    @objc(batchOperations:completionHandler:)
+    @discardableResult public func z_objc_batch(operations: [Any], completionHandler: CompletionHandler?) -> Operation {
+        return self.batch(operations: operations, completionHandler: completionHandler)
     }
 }

--- a/Source/Index.swift
+++ b/Source/Index.swift
@@ -60,13 +60,19 @@ import Foundation
     /// Add an object to this index.
     ///
     /// - parameter object: The object to add.
+    /// - parameter requestOptions: Request-specific options.
     /// - parameter completionHandler: Completion handler to be notified of the request's outcome.
     /// - returns: A cancellable operation.
     ///
     @objc
-    @discardableResult public func addObject(_ object: JSONObject, completionHandler: CompletionHandler? = nil) -> Operation {
+    @discardableResult public func addObject(_ object: JSONObject, requestOptions: RequestOptions? = nil, completionHandler: CompletionHandler? = nil) -> Operation {
         let path = "1/indexes/\(urlEncodedName)"
-        return client.performHTTPQuery(path: path, method: .POST, body: object, hostnames: client.writeHosts, completionHandler: completionHandler)
+        return client.performHTTPQuery(path: path, method: .POST, body: object, hostnames: client.writeHosts, requestOptions: requestOptions, completionHandler: completionHandler)
+    }
+    
+    @objc(addObject:completionHandler:)
+    @discardableResult public func z_objc_addObject(_ object: JSONObject, completionHandler: CompletionHandler?) -> Operation {
+        return self.addObject(object, requestOptions: nil, completionHandler: completionHandler)
     }
     
     /// Add an object to this index, assigning it the specified object ID.
@@ -74,23 +80,30 @@ import Foundation
     ///
     /// - parameter object: The object to add.
     /// - parameter objectID: Identifier that you want to assign this object.
+    /// - parameter requestOptions: Request-specific options.
     /// - parameter completionHandler: Completion handler to be notified of the request's outcome.
     /// - returns: A cancellable operation.
     ///
     @objc
-    @discardableResult public func addObject(_ object: JSONObject, withID objectID: String, completionHandler: CompletionHandler? = nil) -> Operation {
+    @discardableResult public func addObject(_ object: JSONObject, withID objectID: String, requestOptions: RequestOptions? = nil, completionHandler: CompletionHandler? = nil) -> Operation {
         let path = "1/indexes/\(urlEncodedName)/\(objectID.urlEncodedPathComponent())"
-        return client.performHTTPQuery(path: path, method: .PUT, body: object, hostnames: client.writeHosts, completionHandler: completionHandler)
+        return client.performHTTPQuery(path: path, method: .PUT, body: object, hostnames: client.writeHosts, requestOptions: requestOptions, completionHandler: completionHandler)
+    }
+    
+    @objc(addObject:withID:completionHandler:)
+    @discardableResult public func z_objc_addObject(_ object: JSONObject, withID objectID: String, completionHandler: CompletionHandler?) -> Operation {
+        return self.addObject(object, withID: objectID, completionHandler: completionHandler)
     }
     
     /// Add several objects to this index.
     ///
     /// - parameter objects: Objects to add.
+    /// - parameter requestOptions: Request-specific options.
     /// - parameter completionHandler: Completion handler to be notified of the request's outcome.
     /// - returns: A cancellable operation.
     ///
     @objc
-    @discardableResult public func addObjects(_ objects: [JSONObject], completionHandler: CompletionHandler? = nil) -> Operation {
+    @discardableResult public func addObjects(_ objects: [JSONObject], requestOptions: RequestOptions? = nil, completionHandler: CompletionHandler? = nil) -> Operation {
         let path = "1/indexes/\(urlEncodedName)/batch"
         
         var requests = [Any]()
@@ -100,29 +113,41 @@ import Foundation
         }
         let request = ["requests": requests]
         
-        return client.performHTTPQuery(path: path, method: .POST, body: request, hostnames: client.writeHosts, completionHandler: completionHandler)
+        return client.performHTTPQuery(path: path, method: .POST, body: request, hostnames: client.writeHosts, requestOptions: requestOptions, completionHandler: completionHandler)
+    }
+    
+    @objc(addObjects:completionHandler:)
+    @discardableResult public func z_objc_addObjects(_ objects: [JSONObject], completionHandler: CompletionHandler?) -> Operation {
+        return self.addObjects(objects, completionHandler: completionHandler)
     }
     
     /// Delete an object from this index.
     ///
     /// - parameter objectID: Identifier of object to delete.
+    /// - parameter requestOptions: Request-specific options.
     /// - parameter completionHandler: Completion handler to be notified of the request's outcome.
     /// - returns: A cancellable operation.
     ///
     @objc
-    @discardableResult public func deleteObject(withID objectID: String, completionHandler: CompletionHandler? = nil) -> Operation {
+    @discardableResult public func deleteObject(withID objectID: String, requestOptions: RequestOptions? = nil, completionHandler: CompletionHandler? = nil) -> Operation {
         let path = "1/indexes/\(urlEncodedName)/\(objectID.urlEncodedPathComponent())"
-        return client.performHTTPQuery(path: path, method: .DELETE, body: nil, hostnames: client.writeHosts, completionHandler: completionHandler)
+        return client.performHTTPQuery(path: path, method: .DELETE, body: nil, hostnames: client.writeHosts, requestOptions: requestOptions, completionHandler: completionHandler)
+    }
+    
+    @objc(deleteObjectWithID:completionHandler:)
+    @discardableResult public func z_objc_deleteObject(withID objectID: String, completionHandler: CompletionHandler?) -> Operation {
+        return self.deleteObject(withID: objectID, completionHandler: completionHandler)
     }
     
     /// Delete several objects from this index.
     ///
     /// - parameter objectIDs: Identifiers of objects to delete.
+    /// - parameter requestOptions: Request-specific options.
     /// - parameter completionHandler: Completion handler to be notified of the request's outcome.
     /// - returns: A cancellable operation.
     ///
     @objc
-    @discardableResult public func deleteObjects(withIDs objectIDs: [String], completionHandler: CompletionHandler? = nil) -> Operation {
+    @discardableResult public func deleteObjects(withIDs objectIDs: [String], requestOptions: RequestOptions? = nil, completionHandler: CompletionHandler? = nil) -> Operation {
         let path = "1/indexes/\(urlEncodedName)/batch"
         
         var requests = [Any]()
@@ -132,18 +157,12 @@ import Foundation
         }
         let request = ["requests": requests]
         
-        return client.performHTTPQuery(path: path, method: .POST, body: request, hostnames: client.writeHosts, completionHandler: completionHandler)
+        return client.performHTTPQuery(path: path, method: .POST, body: request, hostnames: client.writeHosts, requestOptions: requestOptions, completionHandler: completionHandler)
     }
     
-    /// Get an object from this index.
-    ///
-    /// - parameter objectID: Identifier of the object to retrieve.
-    /// - parameter completionHandler: Completion handler to be notified of the request's outcome.
-    /// - returns: A cancellable operation.
-    ///
-    @objc
-    @discardableResult public func getObject(withID objectID: String, completionHandler: @escaping CompletionHandler) -> Operation {
-        return getObject(withID: objectID, attributesToRetrieve: nil, completionHandler: completionHandler)
+    @objc(deleteObjectsWithIDs:completionHandler:)
+    @discardableResult public func z_objc_deleteObjects(withIDs objectIDs: [String], completionHandler: CompletionHandler?) -> Operation {
+        return self.deleteObjects(withIDs: objectIDs, completionHandler: completionHandler)
     }
     
     /// Get an object from this index, optionally restricting the retrieved content.
@@ -151,38 +170,39 @@ import Foundation
     /// - parameter objectID: Identifier of the object to retrieve.
     /// - parameter attributesToRetrieve: List of attributes to retrieve. If `nil`, all attributes are retrieved.
     ///                                   If one of the elements is `"*"`, all attributes are retrieved.
+    /// - parameter requestOptions: Request-specific options.
     /// - parameter completionHandler: Completion handler to be notified of the request's outcome.
     /// - returns: A cancellable operation.
     ///
     @objc
-    @discardableResult public func getObject(withID objectID: String, attributesToRetrieve: [String]?, completionHandler: @escaping CompletionHandler) -> Operation {
+    @discardableResult public func getObject(withID objectID: String, attributesToRetrieve: [String]? = nil, requestOptions: RequestOptions? = nil, completionHandler: @escaping CompletionHandler) -> Operation {
         let query = Query()
         query.attributesToRetrieve = attributesToRetrieve
-        let path = "1/indexes/\(urlEncodedName)/\(objectID.urlEncodedPathComponent())?\(query.build())"
-        return client.performHTTPQuery(path: path, method: .GET, body: nil, hostnames: client.readHosts, completionHandler: completionHandler)
+        let path = "1/indexes/\(urlEncodedName)/\(objectID.urlEncodedPathComponent())"
+        return client.performHTTPQuery(path: path, urlParameters: query.parameters, method: .GET, body: nil, hostnames: client.readHosts, requestOptions: requestOptions, completionHandler: completionHandler)
     }
     
-    /// Get several objects from this index.
-    ///
-    /// - parameter objectIDs: Identifiers of objects to retrieve.
-    /// - parameter completionHandler: Completion handler to be notified of the request's outcome.
-    /// - returns: A cancellable operation.
-    ///
-    @objc
-    @discardableResult public func getObjects(withIDs objectIDs: [String], completionHandler: @escaping CompletionHandler) -> Operation {
-        return getObjects(withIDs: objectIDs, attributesToRetrieve: nil, completionHandler: completionHandler)
+    @objc(getObjectWithID:completionHandler:)
+    @discardableResult public func z_objc_getObject(withID objectID: String, completionHandler: @escaping CompletionHandler) -> Operation {
+        return getObject(withID: objectID, completionHandler: completionHandler)
     }
-
+    
+    @objc(getObjectWithID:attributesToRetrieve:completionHandler:)
+    @discardableResult public func z_objc_getObject(withID objectID: String, attributesToRetrieve: [String]?, completionHandler: @escaping CompletionHandler) -> Operation {
+        return self.getObject(withID: objectID, attributesToRetrieve: attributesToRetrieve, completionHandler: completionHandler)
+    }
+    
     /// Get several objects from this index, optionally restricting the retrieved content.
     ///
     /// - parameter objectIDs: Identifiers of objects to retrieve.
     /// - parameter attributesToRetrieve: List of attributes to retrieve. If `nil`, all attributes are retrieved.
     ///                                   If one of the elements is `"*"`, all attributes are retrieved.
+    /// - parameter requestOptions: Request-specific options.
     /// - parameter completionHandler: Completion handler to be notified of the request's outcome.
     /// - returns: A cancellable operation.
     ///
     @objc
-    @discardableResult public func getObjects(withIDs objectIDs: [String], attributesToRetrieve: [String]?, completionHandler: @escaping CompletionHandler) -> Operation {
+    @discardableResult public func getObjects(withIDs objectIDs: [String], attributesToRetrieve: [String]? = nil, requestOptions: RequestOptions? = nil, completionHandler: @escaping CompletionHandler) -> Operation {
         let path = "1/indexes/*/objects"
         var requests = [Any]()
         requests.reserveCapacity(objectIDs.count)
@@ -194,76 +214,60 @@ import Foundation
             request["attributesToRetrieve"] = attributesToRetrieve?.joined(separator: ",")
             requests.append(request as Any)
         }
-        return client.performHTTPQuery(path: path, method: .POST, body: ["requests": requests], hostnames: client.readHosts, completionHandler: completionHandler)
+        return client.performHTTPQuery(path: path, method: .POST, body: ["requests": requests], hostnames: client.readHosts, requestOptions: requestOptions, completionHandler: completionHandler)
+    }
+    
+    @objc(getObjectsWithIDs:completionHandler:)
+    @discardableResult public func z_objc_getObjects(withIDs objectIDs: [String], completionHandler: @escaping CompletionHandler) -> Operation {
+        return getObjects(withIDs: objectIDs, attributesToRetrieve: nil, completionHandler: completionHandler)
+    }
+    
+    @objc(getObjectsWithIDs:attributesToRetrieve:completionHandler:)
+    @discardableResult public func z_objc_getObjects(withIDs objectIDs: [String], attributesToRetrieve: [String]?, completionHandler: @escaping CompletionHandler) -> Operation {
+        return getObjects(withIDs: objectIDs, attributesToRetrieve: attributesToRetrieve, completionHandler: completionHandler)
     }
     
     /// Partially update an object.
     ///
     /// - parameter partialObject: New values/operations for the object.
     /// - parameter objectID: Identifier of object to be updated.
+    /// - parameter createIfNotExists: Whether an update on a nonexistent object ID should create the object.
+    /// - parameter requestOptions: Request-specific options.
     /// - parameter completionHandler: Completion handler to be notified of the request's outcome.
     /// - returns: A cancellable operation.
     ///
-    /// + Note: If the object does not exist, it will be created. You can avoid automatic creation of the object by
-    ///   passing `false` to `createIfNotExists` in `partialUpdateObject(_:withID:createIfNotExists:completionHandler:)`.
-    ///
-    @objc
-    @discardableResult public func partialUpdateObject(_ partialObject: JSONObject, withID objectID: String, completionHandler: CompletionHandler? = nil) -> Operation {
+    @discardableResult public func partialUpdateObject(_ partialObject: JSONObject, withID objectID: String, createIfNotExists: Bool? = nil, requestOptions: RequestOptions? = nil, completionHandler: CompletionHandler? = nil) -> Operation {
         let path = "1/indexes/\(urlEncodedName)/\(objectID.urlEncodedPathComponent())/partial"
-        return client.performHTTPQuery(path: path, method: .POST, body: partialObject, hostnames: client.writeHosts, completionHandler: completionHandler)
+        let urlParameters = createIfNotExists != nil ? ["createIfNotExists": String(createIfNotExists!)] : nil
+        return client.performHTTPQuery(path: path, urlParameters: urlParameters, method: .POST, body: partialObject, hostnames: client.writeHosts, requestOptions: requestOptions, completionHandler: completionHandler)
     }
     
-    /// Partially update an object.
-    ///
-    /// - parameter partialObject: New values/operations for the object.
-    /// - parameter objectID: Identifier of object to be updated.
-    /// - parameter createIfNotExists: Whether an update on a nonexistent object ID should create the object.
-    /// - parameter completionHandler: Completion handler to be notified of the request's outcome.
-    /// - returns: A cancellable operation.
-    ///
-    @objc
-    @discardableResult public func partialUpdateObject(_ partialObject: JSONObject, withID objectID: String, createIfNotExists: Bool, completionHandler: CompletionHandler? = nil) -> Operation {
-        let path = "1/indexes/\(urlEncodedName)/\(objectID.urlEncodedPathComponent())/partial?createIfNotExists=\(String(createIfNotExists).urlEncodedQueryParam())"
-        return client.performHTTPQuery(path: path, method: .POST, body: partialObject, hostnames: client.writeHosts, completionHandler: completionHandler)
+    @objc(partialUpdateObject:withID:completionHandler:)
+    @discardableResult public func z_objc_partialUpdateObject(_ partialObject: JSONObject, withID objectID: String, completionHandler: CompletionHandler?) -> Operation {
+        return self.partialUpdateObject(partialObject, withID: objectID, completionHandler: completionHandler)
     }
-
-    /// Partially update several objects.
-    ///
-    /// - parameter objects: New values/operations for the objects. Each object must contain an `objectID` attribute.
-    /// - parameter completionHandler: Completion handler to be notified of the request's outcome.
-    /// - returns: A cancellable operation.
-    ///
-    /// + Note: If an object does not exist, it will be created. You can avoid automatic creation of objects by
-    ///   passing `false` to `createIfNotExists` in `partialUpdateObjects(_:createIfNotExists:completionHandler:)`.
-    ///
-    @objc
-    @discardableResult public func partialUpdateObjects(_ objects: [JSONObject], completionHandler: CompletionHandler? = nil) -> Operation {
-        let path = "1/indexes/\(urlEncodedName)/batch"
-        
-        var requests = [Any]()
-        requests.reserveCapacity(objects.count)
-        for object in objects {
-            requests.append([
-                "action": "partialUpdateObject",
-                "objectID": object["objectID"] as! String,
-                "body": object
-            ])
-        }
-        let request = ["requests": requests]
-        
-        return client.performHTTPQuery(path: path, method: .POST, body: request, hostnames: client.writeHosts, completionHandler: completionHandler)
+    
+    @objc(partialUpdateObject:withID:createIfNotExists:completionHandler:)
+    @discardableResult public func z_objc_partialUpdateObject(_ partialObject: JSONObject, withID objectID: String, createIfNotExists: Bool, completionHandler: CompletionHandler?) -> Operation {
+        return self.partialUpdateObject(partialObject, withID: objectID, createIfNotExists: createIfNotExists, completionHandler: completionHandler)
     }
-
+    
+    @objc(partialUpdateObject:withID:createIfNotExists:requestOptions:completionHandler:)
+    @discardableResult public func z_objc_partialUpdateObject(_ partialObject: JSONObject, withID objectID: String, createIfNotExists: Bool, requestOptions: RequestOptions?, completionHandler: CompletionHandler?) -> Operation {
+        return self.partialUpdateObject(partialObject, withID: objectID, createIfNotExists: createIfNotExists, requestOptions: requestOptions, completionHandler: completionHandler)
+    }
+    
     /// Partially update several objects.
     ///
     /// - parameter objects: New values/operations for the objects. Each object must contain an `objectID` attribute.
     /// - parameter createIfNotExists: Whether an update on a nonexistent object ID should create the object.
+    /// - parameter requestOptions: Request-specific options.
     /// - parameter completionHandler: Completion handler to be notified of the request's outcome.
     /// - returns: A cancellable operation.
     ///
-    @objc
-    @discardableResult public func partialUpdateObjects(_ objects: [JSONObject], createIfNotExists: Bool, completionHandler: CompletionHandler? = nil) -> Operation {
+    @discardableResult public func partialUpdateObjects(_ objects: [JSONObject], createIfNotExists: Bool? = nil, requestOptions: RequestOptions? = nil, completionHandler: CompletionHandler? = nil) -> Operation {
         let path = "1/indexes/\(urlEncodedName)/batch"
+        let createIfNotExists = createIfNotExists ?? true
         let action = createIfNotExists ? "partialUpdateObject" : "partialUpdateObjectNoCreate"
         var requests = [Any]()
         requests.reserveCapacity(objects.count)
@@ -276,30 +280,52 @@ import Foundation
         }
         let request = ["requests": requests]
         
-        return client.performHTTPQuery(path: path, method: .POST, body: request, hostnames: client.writeHosts, completionHandler: completionHandler)
+        return client.performHTTPQuery(path: path, method: .POST, body: request, hostnames: client.writeHosts, requestOptions: requestOptions, completionHandler: completionHandler)
     }
 
+    @objc(partialUpdateObjects:completionHandler:)
+    @discardableResult public func z_objc_partialUpdateObjects(_ objects: [JSONObject], completionHandler: CompletionHandler?) -> Operation {
+        return self.partialUpdateObjects(objects, completionHandler: completionHandler)
+    }
+    
+    @objc(partialUpdateObjects:createIfNotExists:completionHandler:)
+    @discardableResult public func z_objc_partialUpdateObjects(_ objects: [JSONObject], createIfNotExists: Bool, completionHandler: CompletionHandler?) -> Operation {
+        return self.partialUpdateObjects(objects, createIfNotExists: createIfNotExists, completionHandler: completionHandler)
+    }
+    
+    @objc(partialUpdateObjects:createIfNotExists:requestOptions:completionHandler:)
+    @discardableResult public func z_objc_partialUpdateObjects(_ objects: [JSONObject], createIfNotExists: Bool, requestOptions: RequestOptions?, completionHandler: CompletionHandler?) -> Operation {
+        return self.partialUpdateObjects(objects, createIfNotExists: createIfNotExists, requestOptions: requestOptions, completionHandler: completionHandler)
+    }
+    
     /// Update an object.
     ///
     /// - parameter object: New version of the object to update. Must contain an `objectID` attribute.
+    /// - parameter requestOptions: Request-specific options.
     /// - parameter completionHandler: Completion handler to be notified of the request's outcome.
     /// - returns: A cancellable operation.
     ///
     @objc
-    @discardableResult public func saveObject(_ object: JSONObject, completionHandler: CompletionHandler? = nil) -> Operation {
+    @discardableResult public func saveObject(_ object: JSONObject, requestOptions: RequestOptions? = nil, completionHandler: CompletionHandler? = nil) -> Operation {
         let objectID = object["objectID"] as! String
         let path = "1/indexes/\(urlEncodedName)/\(objectID.urlEncodedPathComponent())"
-        return client.performHTTPQuery(path: path, method: .PUT, body: object, hostnames: client.writeHosts, completionHandler: completionHandler)
+        return client.performHTTPQuery(path: path, method: .PUT, body: object, hostnames: client.writeHosts, requestOptions: requestOptions, completionHandler: completionHandler)
+    }
+    
+    @objc(saveObject:completionHandler:)
+    @discardableResult public func z_objc_saveObject(_ object: JSONObject, completionHandler: CompletionHandler?) -> Operation {
+        return self.saveObject(object, completionHandler: completionHandler)
     }
     
     /// Update several objects.
     ///
     /// - parameter objects: New versions of the objects to update. Each one must contain an `objectID` attribute.
+    /// - parameter requestOptions: Request-specific options.
     /// - parameter completionHandler: Completion handler to be notified of the request's outcome.
     /// - returns: A cancellable operation.
     ///
     @objc
-    @discardableResult public func saveObjects(_ objects: [JSONObject], completionHandler: CompletionHandler? = nil) -> Operation {
+    @discardableResult public func saveObjects(_ objects: [JSONObject], requestOptions: RequestOptions? = nil, completionHandler: CompletionHandler? = nil) -> Operation {
         let path = "1/indexes/\(urlEncodedName)/batch"
         
         var requests = [Any]()
@@ -313,21 +339,27 @@ import Foundation
         }
         let request = ["requests": requests]
         
-        return client.performHTTPQuery(path: path, method: .POST, body: request, hostnames: client.writeHosts, completionHandler: completionHandler)
+        return client.performHTTPQuery(path: path, method: .POST, body: request, hostnames: client.writeHosts, requestOptions: requestOptions, completionHandler: completionHandler)
     }
     
+    @objc(saveObjects:completionHandler:)
+    @discardableResult public func z_objc_saveObjects(_ objects: [JSONObject], completionHandler: CompletionHandler?) -> Operation {
+        return self.saveObjects(objects, completionHandler: completionHandler)
+    }
     /// Search this index.
     ///
     /// - parameter query: Search parameters.
+    /// - parameter requestOptions: Request-specific options.
     /// - parameter completionHandler: Completion handler to be notified of the request's outcome.
     /// - returns: A cancellable operation.
     ///
     @objc
-    @discardableResult public func search(_ query: Query, completionHandler: @escaping CompletionHandler) -> Operation {
+    @discardableResult public func search(_ query: Query, requestOptions: RequestOptions? = nil, completionHandler: @escaping CompletionHandler) -> Operation {
         let path = "1/indexes/\(urlEncodedName)/query"
         let request = ["params": query.build()]
         
         // First try the in-memory query cache.
+        // FIXME: We should not cache result if the request options have changed.
         let cacheKey = "\(path)_body_\(request)"
         if let content = searchCache?.objectForKey(cacheKey) {
             // We *have* to return something, so we create a simple operation.
@@ -340,7 +372,7 @@ import Foundation
         }
         // Otherwise, run an online query.
         else {
-            return client.performHTTPQuery(path: path, method: .POST, body: request, hostnames: client.readHosts, isSearchQuery: true) {
+            return client.performHTTPQuery(path: path, method: .POST, body: request, hostnames: client.readHosts, isSearchQuery: true, requestOptions: requestOptions) {
                 (content, error) -> Void in
                 assert(content != nil || error != nil)
                 
@@ -353,6 +385,11 @@ import Foundation
         }
     }
     
+    @objc(search:completionHandler:)
+    @discardableResult public func z_objc_search(_ query: Query, completionHandler: @escaping CompletionHandler) -> Operation {
+        return self.search(query, completionHandler: completionHandler)
+    }
+    
     /// Search for facet values.
     /// This searches inside a facet's values, optionally restricting the returned values to those contained in objects
     /// matching other (regular) search criteria.
@@ -363,46 +400,43 @@ import Foundation
     /// - parameter query: An optional query to take extra search parameters into account. These parameters apply to
     ///       index objects like in a regular search query. Only facet values contained in the matched objects will be
     ///       returned.
+    /// - parameter requestOptions: Request-specific options.
     /// - parameter completionHandler: Completion handler to be notified of the request's outcome.
     /// - returns: A cancellable operation.
     ///
-    @objc(searchForFacetValuesOf:matching:query:completionHandler:)
-    @discardableResult public func searchForFacetValues(of facetName: String, matching text: String, query: Query? = nil, completionHandler: @escaping CompletionHandler) -> Operation {
+    @discardableResult public func searchForFacetValues(of facetName: String, matching text: String, query: Query? = nil, requestOptions: RequestOptions? = nil, completionHandler: @escaping CompletionHandler) -> Operation {
         let path = "1/indexes/\(urlEncodedName)/facets/\(facetName.urlEncodedPathComponent())/query"
         let params = query != nil ? Query(copy: query!) : Query()
         params["facetQuery"] = text
         let requestBody = [
             "params": params.build()
         ]
-        return client.performHTTPQuery(path: path, method: .POST, body: requestBody, hostnames: client.readHosts, isSearchQuery: true, completionHandler: completionHandler)
+        return client.performHTTPQuery(path: path, method: .POST, body: requestBody, hostnames: client.readHosts, isSearchQuery: true, requestOptions: requestOptions, completionHandler: completionHandler)
+    }
+    
+    @objc(searchForFacetValuesOf:matching:query:completionHandler:)
+    @discardableResult public func z_objc_searchForFacetValues(of facetName: String, matching text: String, query: Query?, completionHandler: @escaping CompletionHandler) -> Operation {
+        return self.searchForFacetValues(of: facetName, matching: text, query: query, completionHandler: completionHandler)
     }
     
     /// Get this index's settings.
     ///
+    /// - parameter requestOptions: Request-specific options.
     /// - parameter completionHandler: Completion handler to be notified of the request's outcome.
     /// - returns: A cancellable operation.
     ///
-    @objc(getSettings:)
-    @discardableResult public func getSettings(completionHandler: @escaping CompletionHandler) -> Operation {
-        let path = "1/indexes/\(urlEncodedName)/settings?getVersion=2"
-        return client.performHTTPQuery(path: path, method: .GET, body: nil, hostnames: client.readHosts, completionHandler: completionHandler)
+    @objc(getSettingsWithRequestOptions:completionHandler:)
+    @discardableResult public func getSettings(requestOptions: RequestOptions? = nil, completionHandler: @escaping CompletionHandler) -> Operation {
+        let path = "1/indexes/\(urlEncodedName)/settings"
+        let urlParameters = ["getVersion": "2"]
+        return client.performHTTPQuery(path: path, urlParameters: urlParameters, method: .GET, body: nil, hostnames: client.readHosts, requestOptions: requestOptions, completionHandler: completionHandler)
     }
     
-    /// Set this index's settings.
-    ///
-    /// Please refer to our [API documentation](https://www.algolia.com/doc/swift#index-settings) for the list of
-    /// supported settings.
-    ///
-    /// - parameter settings: New settings.
-    /// - parameter completionHandler: Completion handler to be notified of the request's outcome.
-    /// - returns: A cancellable operation.
-    ///
-    @objc
-    @discardableResult public func setSettings(_ settings: JSONObject, completionHandler: CompletionHandler? = nil) -> Operation {
-        let path = "1/indexes/\(urlEncodedName)/settings"
-        return client.performHTTPQuery(path: path, method: .PUT, body: settings, hostnames: client.writeHosts, completionHandler: completionHandler)
+    @objc(getSettings:)
+    @discardableResult public func z_objc_getSettings(completionHandler: @escaping CompletionHandler) -> Operation {
+        return self.getSettings(completionHandler:completionHandler)
     }
-
+    
     /// Set this index's settings, optionally forwarding the change to replicas.
     ///
     /// Please refer to our [API documentation](https://www.algolia.com/doc/swift#index-settings) for the list of
@@ -410,37 +444,60 @@ import Foundation
     ///
     /// - parameter settings: New settings.
     /// - parameter forwardToReplicas: When true, the change is also applied to replicas of this index.
+    /// - parameter requestOptions: Request-specific options.
     /// - parameter completionHandler: Completion handler to be notified of the request's outcome.
     /// - returns: A cancellable operation.
     ///
-    @objc
-    @discardableResult public func setSettings(_ settings: JSONObject, forwardToReplicas: Bool, completionHandler: CompletionHandler? = nil) -> Operation {
-        let path = "1/indexes/\(urlEncodedName)/settings?forwardToReplicas=\(forwardToReplicas)"
-        return client.performHTTPQuery(path: path, method: .PUT, body: settings, hostnames: client.writeHosts, completionHandler: completionHandler)
+    @discardableResult public func setSettings(_ settings: JSONObject, forwardToReplicas: Bool? = nil, requestOptions: RequestOptions? = nil, completionHandler: CompletionHandler? = nil) -> Operation {
+        let path = "1/indexes/\(urlEncodedName)/settings"
+        let urlParameters = forwardToReplicas != nil ? ["forwardToReplicas": String(forwardToReplicas!)] : nil
+        return client.performHTTPQuery(path: path, urlParameters: urlParameters, method: .PUT, body: settings, hostnames: client.writeHosts, requestOptions: requestOptions, completionHandler: completionHandler)
     }
-
+    
+    @objc(setSettings:completionHandler:)
+    @discardableResult public func z_objc_setSettings(_ settings: JSONObject, completionHandler: CompletionHandler?) -> Operation {
+        return self.setSettings(settings, completionHandler: completionHandler)
+    }
+    
+    @objc(setSettings:forwardToReplicas:completionHandler:)
+    @discardableResult public func z_objc_setSettings(_ settings: JSONObject, forwardToReplicas: Bool, completionHandler: CompletionHandler?) -> Operation {
+        return self.setSettings(settings, forwardToReplicas: forwardToReplicas, completionHandler: completionHandler)
+    }
+    
     /// Delete the index content without removing settings and index specific API keys.
     ///
+    /// - parameter requestOptions: Request-specific options.
     /// - parameter completionHandler: Completion handler to be notified of the request's outcome.
     /// - returns: A cancellable operation.
     ///
-    @objc(clearIndex:)
-    @discardableResult public func clearIndex(completionHandler: CompletionHandler? = nil) -> Operation {
+    @objc(clearIndexWithRequestOptions:completionHandler:)
+    @discardableResult public func clearIndex(requestOptions: RequestOptions? = nil, completionHandler: CompletionHandler? = nil) -> Operation {
         let path = "1/indexes/\(urlEncodedName)/clear"
-        return client.performHTTPQuery(path: path, method: .POST, body: nil, hostnames: client.writeHosts, completionHandler: completionHandler)
+        return client.performHTTPQuery(path: path, method: .POST, body: nil, hostnames: client.writeHosts, requestOptions: requestOptions, completionHandler: completionHandler)
+    }
+    
+    @objc(clearIndex:)
+    @discardableResult public func z_objc_clearIndex(completionHandler: CompletionHandler?) -> Operation {
+        return self.clearIndex(completionHandler: completionHandler)
     }
     
     /// Batch operations.
     ///
     /// - parameter operations: The array of actions.
+    /// - parameter requestOptions: Request-specific options.
     /// - parameter completionHandler: Completion handler to be notified of the request's outcome.
     /// - returns: A cancellable operation.
     ///
-    @objc(batchOperations:completionHandler:)
-    @discardableResult public func batch(operations: [JSONObject], completionHandler: CompletionHandler? = nil) -> Operation {
+    @objc(batchOperations:requestOptions:completionHandler:)
+    @discardableResult public func batch(operations: [JSONObject], requestOptions: RequestOptions? = nil, completionHandler: CompletionHandler? = nil) -> Operation {
         let path = "1/indexes/\(urlEncodedName)/batch"
         let body = ["requests": operations]
-        return client.performHTTPQuery(path: path, method: .POST, body: body, hostnames: client.writeHosts, completionHandler: completionHandler)
+        return client.performHTTPQuery(path: path, method: .POST, body: body, hostnames: client.writeHosts, requestOptions: requestOptions, completionHandler: completionHandler)
+    }
+    
+    @objc(batchOperations:completionHandler:)
+    @discardableResult public func z_objc_batch(operations: [JSONObject], completionHandler: CompletionHandler? = nil) -> Operation {
+        return self.batch(operations: operations, completionHandler: completionHandler)
     }
     
     /// Browse all index content (initial call).
@@ -448,16 +505,22 @@ import Foundation
     /// unless the end of the index has been reached. To retrieve subsequent pages, call `browseFrom` with that cursor.
     ///
     /// - parameter query: The query parameters for the browse.
+    /// - parameter requestOptions: Request-specific options.
     /// - parameter completionHandler: Completion handler to be notified of the request's outcome.
     /// - returns: A cancellable operation.
     ///
-    @objc(browseWithQuery:completionHandler:)
-    @discardableResult public func browse(query: Query, completionHandler: @escaping CompletionHandler) -> Operation {
+    @objc(browseWithQuery:requestOptions:completionHandler:)
+    @discardableResult public func browse(query: Query, requestOptions: RequestOptions? = nil, completionHandler: @escaping CompletionHandler) -> Operation {
         let path = "1/indexes/\(urlEncodedName)/browse"
         let body = [
             "params": query.build()
         ]
-        return client.performHTTPQuery(path: path, method: .POST, body: body, hostnames: client.readHosts, completionHandler: completionHandler)
+        return client.performHTTPQuery(path: path, method: .POST, body: body, hostnames: client.readHosts, requestOptions: requestOptions, completionHandler: completionHandler)
+    }
+    
+    @objc(browseWithQuery:completionHandler:)
+    @discardableResult public func z_objc_browse(query: Query, completionHandler: @escaping CompletionHandler) -> Operation {
+        return self.browse(query: query, completionHandler: completionHandler)
     }
     
     /// Browse the index from a cursor.
@@ -465,13 +528,20 @@ import Foundation
     /// index has been reached.
     ///
     /// - parameter cursor: The cursor of the next page to retrieve
+    /// - parameter requestOptions: Request-specific options.
     /// - parameter completionHandler: Completion handler to be notified of the request's outcome.
     /// - returns: A cancellable operation.
     ///
+    @objc(browseFromCursor:requestOptions:completionHandler:)
+    @discardableResult public func browse(from cursor: String, requestOptions: RequestOptions? = nil, completionHandler: @escaping CompletionHandler) -> Operation {
+        let path = "1/indexes/\(urlEncodedName)/browse"
+        let urlParameters = ["cursor": cursor]
+        return client.performHTTPQuery(path: path, urlParameters: urlParameters, method: .GET, body: nil, hostnames: client.readHosts, requestOptions: requestOptions, completionHandler: completionHandler)
+    }
+    
     @objc(browseFromCursor:completionHandler:)
-    @discardableResult public func browse(from cursor: String, completionHandler: @escaping CompletionHandler) -> Operation {
-        let path = "1/indexes/\(urlEncodedName)/browse?cursor=\(cursor.urlEncodedQueryParam())"
-        return client.performHTTPQuery(path: path, method: .GET, body: nil, hostnames: client.readHosts, completionHandler: completionHandler)
+    @discardableResult public func z_objc_browse(from cursor: String, completionHandler: @escaping CompletionHandler) -> Operation {
+        return self.browse(from: cursor, completionHandler: completionHandler)
     }
     
     // MARK: - Helpers
@@ -480,19 +550,26 @@ import Foundation
     /// All server tasks are asynchronous. This method helps you check that a task is published.
     ///
     /// - parameter taskID: Identifier of the task (as returned by the server).
+    /// - parameter requestOptions: Request-specific options.
     /// - parameter completionHandler: Completion handler to be notified of the request's outcome.
     /// - returns: A cancellable operation.
     ///
     @objc
-    @discardableResult public func waitTask(withID taskID: Int, completionHandler: @escaping CompletionHandler) -> Operation {
-        let operation = WaitOperation(index: self, taskID: taskID, completionHandler: completionHandler)
+    @discardableResult public func waitTask(withID taskID: Int, requestOptions: RequestOptions? = nil, completionHandler: @escaping CompletionHandler) -> Operation {
+        let operation = WaitOperation(index: self, taskID: taskID, requestOptions: requestOptions, completionHandler: completionHandler)
         client.inMemoryQueue.addOperation(operation)
         return operation
     }
     
+    @objc(waitTaskWithID:completionHandler:)
+    @discardableResult public func z_objc_waitTask(withID taskID: Int, completionHandler: @escaping CompletionHandler) -> Operation {
+        return self.waitTask(withID: taskID, completionHandler: completionHandler)
+    }
+
     private class WaitOperation: AsyncOperationWithCompletion {
         let index: Index
         let taskID: Int
+        let requestOptions: RequestOptions?
         let path: String
         var iteration: Int = 0
         var operation: Operation?
@@ -500,9 +577,10 @@ import Foundation
         static let BASE_DELAY = 0.1     ///< Minimum wait delay.
         static let MAX_DELAY  = 5.0     ///< Maximum wait delay.
         
-        init(index: Index, taskID: Int, completionHandler: @escaping CompletionHandler) {
+        init(index: Index, taskID: Int, requestOptions: RequestOptions?, completionHandler: @escaping CompletionHandler) {
             self.index = index
             self.taskID = taskID
+            self.requestOptions = requestOptions
             path = "1/indexes/\(index.urlEncodedName)/task/\(taskID)"
             super.init(completionHandler: completionHandler)
             self.completionQueue = index.client.completionQueue
@@ -523,7 +601,7 @@ import Foundation
                 return
             }
             iteration += 1
-            operation = index.client.performHTTPQuery(path: path, method: .GET, body: nil, hostnames: index.client.writeHosts) {
+            operation = index.client.performHTTPQuery(path: path, method: .GET, body: nil, hostnames: index.client.writeHosts, requestOptions: requestOptions) {
                 (content, error) -> Void in
                 if let content = content {
                     if (content["status"] as? String) == "published" {
@@ -546,23 +624,31 @@ import Foundation
     /// Delete all objects matching a query (helper).
     ///
     /// - parameter query: The query that objects to delete must match.
+    /// - parameter requestOptions: Request-specific options.
     /// - parameter completionHandler: Completion handler to be notified of the request's outcome.
     /// - returns: A cancellable operation.
     ///
     @objc
-    @discardableResult public func deleteByQuery(_ query: Query, completionHandler: CompletionHandler? = nil) -> Operation {
-        let operation = DeleteByQueryOperation(index: self, query: query, completionHandler: completionHandler)
+    @discardableResult public func deleteByQuery(_ query: Query, requestOptions: RequestOptions? = nil, completionHandler: CompletionHandler? = nil) -> Operation {
+        let operation = DeleteByQueryOperation(index: self, query: query, requestOptions: requestOptions, completionHandler: completionHandler)
         client.inMemoryQueue.addOperation(operation)
         return operation
+    }
+    
+    @objc(deleteByQuery:completionHandler:)
+    @discardableResult public func z_objc_deleteByQuery(_ query: Query, completionHandler: CompletionHandler?) -> Operation {
+        return self.deleteByQuery(query, completionHandler: completionHandler)
     }
     
     private class DeleteByQueryOperation: AsyncOperationWithCompletion {
         let index: Index
         let query: Query
+        let requestOptions: RequestOptions?
         
-        init(index: Index, query: Query, completionHandler: CompletionHandler?) {
+        init(index: Index, query: Query, requestOptions: RequestOptions?, completionHandler: CompletionHandler?) {
             self.index = index
             self.query = Query(copy: query)
+            self.requestOptions = requestOptions
             super.init(completionHandler: completionHandler)
             self.completionQueue = index.client.completionQueue
         }
@@ -571,7 +657,7 @@ import Foundation
             super.start()
             // Save bandwidth by retrieving only the `objectID` attribute.
             query.attributesToRetrieve = ["objectID"]
-            index.browse(query: query, completionHandler: self.handleResult)
+            index.browse(query: query, requestOptions: requestOptions, completionHandler: self.handleResult)
         }
         
         private func handleResult(_ content: JSONObject?, error: Error?) {
@@ -590,7 +676,7 @@ import Foundation
                         }
                     }
                     // Delete the objects.
-                    self.index.deleteObjects(withIDs: objectIDs, completionHandler: { (content, error) in
+                    self.index.deleteObjects(withIDs: objectIDs, requestOptions: self.requestOptions, completionHandler: { (content, error) in
                         if self.isCancelled {
                             return
                         }
@@ -598,7 +684,7 @@ import Foundation
                         if finalError == nil {
                             if let taskID = content?["taskID"] as? Int {
                                 // Wait for the deletion to be effective.
-                                self.index.waitTask(withID: taskID, completionHandler: { (content, error) in
+                                self.index.waitTask(withID: taskID, requestOptions: self.requestOptions, completionHandler: { (content, error) in
                                     if self.isCancelled {
                                         return
                                     }
@@ -606,7 +692,7 @@ import Foundation
                                         self.callCompletion(content: content, error: error)
                                     } else {
                                         // Browse again *from the beginning*, since the deletion invalidated the cursor.
-                                        self.index.browse(query: self.query, completionHandler: self.handleResult)
+                                        self.index.browse(query: self.query, requestOptions: self.requestOptions, completionHandler: self.handleResult)
                                     }
                                 })
                             } else {
@@ -632,30 +718,42 @@ import Foundation
     /// - parameter query: The query.
     /// - parameter disjunctiveFacets: List of disjunctive facets.
     /// - parameter refinements: The current refinements, mapping facet names to a list of values.
+    /// - parameter requestOptions: Request-specific options.
     /// - parameter completionHandler: Completion handler to be notified of the request's outcome.
     /// - returns: A cancellable operation.
     ///
     @objc
-    @discardableResult public func searchDisjunctiveFaceting(_ query: Query, disjunctiveFacets: [String], refinements: [String: [String]], completionHandler: @escaping CompletionHandler) -> Operation {
+    @discardableResult public func searchDisjunctiveFaceting(_ query: Query, disjunctiveFacets: [String], refinements: [String: [String]], requestOptions: RequestOptions? = nil, completionHandler: @escaping CompletionHandler) -> Operation {
         return DisjunctiveFaceting(multipleQuerier: { (queries, completionHandler) in
-            return self.multipleQueries(queries, completionHandler: completionHandler)
+            return self.multipleQueries(queries, requestOptions: requestOptions, completionHandler: completionHandler)
         }).searchDisjunctiveFaceting(query, disjunctiveFacets: disjunctiveFacets, refinements: refinements, completionHandler: completionHandler)
+    }
+    
+    @objc(searchDisjunctiveFaceting:disjunctiveFacets:refinements:completionHandler:)
+    @discardableResult public func z_objc_searchDisjunctiveFaceting(_ query: Query, disjunctiveFacets: [String], refinements: [String: [String]], completionHandler: @escaping CompletionHandler) -> Operation {
+        return self.searchDisjunctiveFaceting(query, disjunctiveFacets: disjunctiveFacets, refinements: refinements, completionHandler: completionHandler)
     }
     
     /// Run multiple queries on this index.
     /// This method is a variant of `Client.multipleQueries(...)` where the targeted index is always the receiver.
     ///
     /// - parameter queries: The queries to run.
+    /// - parameter requestOptions: Request-specific options.
     /// - parameter completionHandler: Completion handler to be notified of the request's outcome.
     /// - returns: A cancellable operation.
     ///
     @objc
-    @discardableResult public func multipleQueries(_ queries: [Query], strategy: String?, completionHandler: @escaping CompletionHandler) -> Operation {
+    @discardableResult public func multipleQueries(_ queries: [Query], strategy: String?, requestOptions: RequestOptions? = nil, completionHandler: @escaping CompletionHandler) -> Operation {
         var requests = [IndexQuery]()
         for query in queries {
             requests.append(IndexQuery(index: self, query: query))
         }
-        return client.multipleQueries(requests, strategy: strategy, completionHandler: completionHandler)
+        return client.multipleQueries(requests, strategy: strategy, requestOptions: requestOptions, completionHandler: completionHandler)
+    }
+    
+    @objc(multipleQueries:strategy:completionHandler:)
+    @discardableResult public func z_objc_multipleQueries(_ queries: [Query], strategy: String?, completionHandler: @escaping CompletionHandler) -> Operation {
+        return self.multipleQueries(queries, strategy: strategy, completionHandler: completionHandler)
     }
     
     /// Run multiple queries on this index.
@@ -663,11 +761,12 @@ import Foundation
     ///
     /// - parameter queries: The queries to run.
     /// - parameter strategy: The strategy to use.
+    /// - parameter requestOptions: Request-specific options.
     /// - parameter completionHandler: Completion handler to be notified of the request's outcome.
     /// - returns: A cancellable operation.
     ///
-    @discardableResult public func multipleQueries(_ queries: [Query], strategy: Client.MultipleQueriesStrategy? = nil, completionHandler: @escaping CompletionHandler) -> Operation {
-        return self.multipleQueries(queries, strategy: strategy?.rawValue, completionHandler: completionHandler)
+    @discardableResult public func multipleQueries(_ queries: [Query], strategy: Client.MultipleQueriesStrategy? = nil, requestOptions: RequestOptions? = nil, completionHandler: @escaping CompletionHandler) -> Operation {
+        return self.multipleQueries(queries, strategy: strategy?.rawValue, requestOptions: requestOptions, completionHandler: completionHandler)
     }
 
     // MARK: - Search Cache

--- a/Source/Index.swift
+++ b/Source/Index.swift
@@ -238,7 +238,7 @@ import Foundation
     ///
     @discardableResult public func partialUpdateObject(_ partialObject: JSONObject, withID objectID: String, createIfNotExists: Bool? = nil, requestOptions: RequestOptions? = nil, completionHandler: CompletionHandler? = nil) -> Operation {
         let path = "1/indexes/\(urlEncodedName)/\(objectID.urlEncodedPathComponent())/partial"
-        let urlParameters = createIfNotExists != nil ? ["createIfNotExists": String(createIfNotExists!)] : nil
+        let urlParameters: [String: String] = createIfNotExists != nil ? ["createIfNotExists": String(createIfNotExists!)] : [:]
         return client.performHTTPQuery(path: path, urlParameters: urlParameters, method: .POST, body: partialObject, hostnames: client.writeHosts, requestOptions: requestOptions, completionHandler: completionHandler)
     }
     
@@ -450,7 +450,7 @@ import Foundation
     ///
     @discardableResult public func setSettings(_ settings: JSONObject, forwardToReplicas: Bool? = nil, requestOptions: RequestOptions? = nil, completionHandler: CompletionHandler? = nil) -> Operation {
         let path = "1/indexes/\(urlEncodedName)/settings"
-        let urlParameters = forwardToReplicas != nil ? ["forwardToReplicas": String(forwardToReplicas!)] : nil
+        let urlParameters: [String: String] = forwardToReplicas != nil ? ["forwardToReplicas": String(forwardToReplicas!)] : [:]
         return client.performHTTPQuery(path: path, urlParameters: urlParameters, method: .PUT, body: settings, hostnames: client.writeHosts, requestOptions: requestOptions, completionHandler: completionHandler)
     }
     

--- a/Source/Offline/OfflineIndex.swift
+++ b/Source/Offline/OfflineIndex.swift
@@ -307,7 +307,7 @@ public struct IOError: CustomNSError {
     /// - returns: A cancellable operation.
     ///
     @discardableResult
-    @objc public func search(_ query: Query, completionHandler: @escaping CompletionHandler) -> Operation {
+    @objc public func search(_ query: Query, requestOptions: RequestOptions? = nil, completionHandler: @escaping CompletionHandler) -> Operation {
         let operation = BlockOperation() {
             let (content, error) = self.searchSync(Query(copy: query))
             self.callCompletionHandler(completionHandler, content: content, error: error)
@@ -315,7 +315,12 @@ public struct IOError: CustomNSError {
         client.offlineSearchQueue.addOperation(operation)
         return operation
     }
-
+    
+    @objc(search:completionHandler:)
+    @discardableResult public func z_objc_search(_ query: Query, completionHandler: @escaping CompletionHandler) -> Operation {
+        return self.search(query, completionHandler: completionHandler)
+    }
+    
     /// Search this index (synchronous version).
     ///
     /// - parameter query: Search parameters.
@@ -468,8 +473,8 @@ public struct IOError: CustomNSError {
     /// Same parameters as `Index.searchForFacetValues(...)`.
     ///
     @discardableResult
-    @objc(searchForFacetValuesOf:matching:query:completionHandler:)
-    public func searchForFacetValues(of facetName: String, matching text: String, query: Query? = nil, completionHandler: @escaping CompletionHandler) -> Operation {
+    @objc(searchForFacetValuesOf:matching:query:requestOptions:completionHandler:)
+    public func searchForFacetValues(of facetName: String, matching text: String, query: Query? = nil, requestOptions: RequestOptions? = nil, completionHandler: @escaping CompletionHandler) -> Operation {
         let queryCopy = query != nil ? Query(copy: query!) : nil
         let operation = BlockOperation() {
             let (content, error) = self.searchForFacetValuesSync(of: facetName, matching: text, query: queryCopy)
@@ -478,7 +483,12 @@ public struct IOError: CustomNSError {
         client.offlineSearchQueue.addOperation(operation)
         return operation
     }
-
+    
+    @objc(searchForFacetValuesOf:matching:query:completionHandler:)
+    @discardableResult public func z_objc_searchForFacetValues(of facetName: String, matching text: String, query: Query, completionHandler: @escaping CompletionHandler) -> Operation {
+        return self.searchForFacetValues(of: facetName, matching: text, query: query, completionHandler: completionHandler)
+    }
+        
     /// Search for facet values (synchronous version).
     ///
     private func searchForFacetValuesSync(of facetName: String, matching text: String, query: Query? = nil) -> APIResponse {
@@ -1031,12 +1041,17 @@ public struct IOError: CustomNSError {
     /// - returns: A cancellable operation.
     ///
     @discardableResult
-    @objc public func searchDisjunctiveFaceting(_ query: Query, disjunctiveFacets: [String], refinements: [String: [String]], completionHandler: @escaping CompletionHandler) -> Operation {
+    @objc public func searchDisjunctiveFaceting(_ query: Query, disjunctiveFacets: [String], refinements: [String: [String]], requestOptions: RequestOptions? = nil, completionHandler: @escaping CompletionHandler) -> Operation {
         return DisjunctiveFaceting(multipleQuerier: { (queries, completionHandler) in
             return self.multipleQueries(queries, completionHandler: completionHandler)
         }).searchDisjunctiveFaceting(query, disjunctiveFacets: disjunctiveFacets, refinements: refinements, completionHandler: completionHandler)
     }
     
+    @objc(searchDisjunctiveFaceting:disjunctiveFacets:refinements:completionHandler:)
+    @discardableResult public func z_objc_searchDisjunctiveFaceting(_ query: Query, disjunctiveFacets: [String], refinements: [String: [String]], completionHandler: @escaping CompletionHandler) -> Operation {
+        return self.searchDisjunctiveFaceting(query, disjunctiveFacets: disjunctiveFacets, refinements: refinements, completionHandler: completionHandler)
+    }
+        
     // ----------------------------------------------------------------------
     // MARK: - Utils
     // ----------------------------------------------------------------------

--- a/Source/RequestOptions.swift
+++ b/Source/RequestOptions.swift
@@ -1,0 +1,72 @@
+//
+//  Copyright (c) 2016 Algolia
+//  http://www.algolia.com/
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+
+/// Per-request options.
+/// This class allows specifying options at the request level, overriding default options at the `Client` level.
+///
+/// + Note: These are reserved for advanced use cases. In most situations, they shouldn't be needed.
+///
+@objc
+public class RequestOptions : NSObject, NSCopying {
+    
+    // MARK: - Low-level storage
+    
+    /// HTTP headers, as untyped values.
+    @objc public var headers: [String: String] = [:]
+    
+    // MARK: - Miscellaneous
+    
+    @objc override open var description: String {
+        get { return "\(String(describing: type(of: self))){\(headers)}" }
+    }
+    
+    // MARK: - Initialization
+    
+    /// Construct request options.
+    ///
+    /// - param headers: HTTP headers (default: empty).
+    ///
+    @objc public init(headers: [String: String] = [:]) {
+    }
+    
+    // MARK: - NSCopying
+    
+    /// Support for `NSCopying`.
+    ///
+    @objc open func copy(with zone: NSZone?) -> Any {
+        // NOTE: As per the docs, the zone argument is ignored.
+        return RequestOptions(headers: self.headers)
+    }
+    
+    // MARK: - Equatable
+    
+    override open func isEqual(_ object: Any?) -> Bool {
+        guard let rhs = object as? RequestOptions else {
+            return false
+        }
+        return self.headers == rhs.headers
+    }
+}

--- a/Source/RequestOptions.swift
+++ b/Source/RequestOptions.swift
@@ -37,6 +37,10 @@ public class RequestOptions : NSObject, NSCopying {
     /// HTTP headers, as untyped values.
     @objc public var headers: [String: String] = [:]
     
+    /// URL parameters, as untyped values.
+    /// These will go into the query string part of the URL (after the question mark).
+    @objc public var urlParameters: [String: String] = [:]
+    
     // MARK: - Miscellaneous
     
     @objc override open var description: String {
@@ -48,8 +52,11 @@ public class RequestOptions : NSObject, NSCopying {
     /// Construct request options.
     ///
     /// - param headers: HTTP headers (default: empty).
+    /// - param urlParameters: URL parameters (default: empty).
     ///
-    @objc public init(headers: [String: String] = [:]) {
+    @objc public init(headers: [String: String] = [:], urlParameters: [String: String] = [:]) {
+        self.headers = headers
+        self.urlParameters = urlParameters
     }
     
     // MARK: - NSCopying

--- a/Source/Searchable.swift
+++ b/Source/Searchable.swift
@@ -35,7 +35,7 @@ import Foundation
     /// - returns: A cancellable operation.
     ///
     @objc
-    @discardableResult func search(_ query: Query, completionHandler: @escaping CompletionHandler) -> Operation
+    @discardableResult func search(_ query: Query, requestOptions: RequestOptions?, completionHandler: @escaping CompletionHandler) -> Operation
     
     /// Perform a search with disjunctive facets, generating as many queries as number of disjunctive facets (helper).
     ///
@@ -46,8 +46,7 @@ import Foundation
     /// - returns: A cancellable operation.
     ///
     @objc
-    @discardableResult func searchDisjunctiveFaceting(_ query: Query, disjunctiveFacets: [String], refinements: [String: [String]], completionHandler: @escaping CompletionHandler) -> Operation
-
+    @discardableResult func searchDisjunctiveFaceting(_ query: Query, disjunctiveFacets: [String], refinements: [String: [String]], requestOptions: RequestOptions?, completionHandler: @escaping CompletionHandler) -> Operation
 
     /// Search for facet values.
     /// This searches inside a facet's values, optionally restricting the returned values to those contained in objects
@@ -63,6 +62,6 @@ import Foundation
     /// - returns: A cancellable operation.
     ///
     @discardableResult
-    @objc(searchForFacetValuesOf:matching:query:completionHandler:)
-    func searchForFacetValues(of facetName: String, matching text: String, query: Query?, completionHandler: @escaping CompletionHandler) -> Operation
+    @objc(searchForFacetValuesOf:matching:query:requestOptions:completionHandler:)
+    func searchForFacetValues(of facetName: String, matching text: String, query: Query?, requestOptions: RequestOptions?, completionHandler: @escaping CompletionHandler) -> Operation
 }

--- a/Tests/ClientTests.swift
+++ b/Tests/ClientTests.swift
@@ -508,4 +508,19 @@ class ClientTests: OnlineTestCase {
         }
         self.waitForExpectations(timeout: expectationTimeout, handler: nil)
     }
+    
+    /// Test that request options are used.
+    ///
+    func testRequestOptions() {
+        let expectation = self.expectation(description: #function)
+        let requestOptions = RequestOptions()
+        requestOptions.headers["X-Algolia-API-Key"] = "ThisIsNotAValidAPIKey"
+        self.client.listIndexes(requestOptions: requestOptions) { (content, error) in
+            XCTAssertNotNil(error)
+            XCTAssert(error is HTTPError)
+            XCTAssertEqual((error as! HTTPError).statusCode, 403)
+            expectation.fulfill()
+        }
+        self.waitForExpectations(timeout: expectationTimeout, handler: nil)
+    }
 }

--- a/Tests/ClientTests.swift
+++ b/Tests/ClientTests.swift
@@ -509,9 +509,9 @@ class ClientTests: OnlineTestCase {
         self.waitForExpectations(timeout: expectationTimeout, handler: nil)
     }
     
-    /// Test that request options are used.
+    /// Test that headers from the request options are used.
     ///
-    func testRequestOptions() {
+    func testRequestOptionsHeaders() {
         let expectation = self.expectation(description: #function)
         let requestOptions = RequestOptions()
         requestOptions.headers["X-Algolia-API-Key"] = "ThisIsNotAValidAPIKey"
@@ -523,4 +523,29 @@ class ClientTests: OnlineTestCase {
         }
         self.waitForExpectations(timeout: expectationTimeout, handler: nil)
     }
+    
+    /// Test that URL parameters from the request options are used.
+    ///
+    func testRequestOptionsURLParameters() {
+        let expectation1 = self.expectation(description: #function)
+        let expectation2 = self.expectation(description: #function)
+        // Listing indices without options should return at least one item.
+        self.client.listIndexes() { (content, error) in
+            XCTAssertNil(error)
+            XCTAssertNotNil(content)
+            XCTAssert(!(content!["items"] as! [JSONObject]).isEmpty)
+            expectation1.fulfill()
+        }
+        // Listing indices with a `page` URL parameter very high should return no items.
+        let requestOptions = RequestOptions()
+        requestOptions.urlParameters["page"] = "666"
+        self.client.listIndexes(requestOptions: requestOptions) { (content, error) in
+            XCTAssertNil(error)
+            XCTAssertNotNil(content)
+            XCTAssert((content!["items"] as! [JSONObject]).isEmpty)
+            expectation2.fulfill()
+        }
+        self.waitForExpectations(timeout: expectationTimeout, handler: nil)
+    }
+    
 }


### PR DESCRIPTION
Adds support for per-request options. The request options are for now an empty shell allowing to override the headers. They will be leveraged in the future to add specific options.