### PR TITLE
Fix Double conversion for the Polygon query

### DIFF
--- a/Source/Query.swift
+++ b/Source/Query.swift
@@ -715,17 +715,13 @@ open class Query : AbstractQuery {
             return nil
         }
         set {
-            if newValue == nil {
-                self["insideBoundingBox"] = nil
-            } else {
-                var components = [String]()
-                for box in newValue! {
-                    components.append(String(box.p1.lat))
-                    components.append(String(box.p1.lng))
-                    components.append(String(box.p2.lat))
-                    components.append(String(box.p2.lng))
-                }
+            if let dstPolygons = newValue {
+                let components = dstPolygons.flatMap({
+                  [String($0.p1.lat), String($0.p1.lng), String($0.p2.lat), String($0.p2.lng)]
+                })
                 self["insideBoundingBox"] = components.joined(separator: ",")
+            } else {
+              self["insideBoundingBox"] = nil
             }
         }
     }
@@ -752,16 +748,10 @@ open class Query : AbstractQuery {
         }
         set {
             if let srcPolygons = newValue {
-                var dstPolygons = [[Double]]()
-                for srcPolygon in srcPolygons {
-                    var dstPolygon = [Double]()
-                    for point in srcPolygon {
-                        dstPolygon.append(point.lat)
-                        dstPolygon.append(point.lng)
-                    }
-                    dstPolygons.append(dstPolygon)
-                }
-                self["insidePolygon"] = AbstractQuery.buildJSONArray(dstPolygons)
+                let components = srcPolygons.map({
+                  "[" + $0.map({ "\(String($0.lat)),\(String($0.lng))"}).joined(separator: ",") + "]"
+                })
+                self["insidePolygon"] = "[" + components.joined(separator: ",") + "]"
             } else {
                 self["insidePolygon"] = nil
             }

--- a/Tests/QueryTests.swift
+++ b/Tests/QueryTests.swift
@@ -624,7 +624,7 @@ class QueryTests: XCTestCase {
         ]
         query1.insidePolygon = POLYGONS
         XCTAssertEqual(query1.insidePolygon! as NSObject, POLYGONS as NSObject)
-        XCTAssertEqual(query1["insidePolygon"], "[[11.111111,22.222222,33.333333,44.444444,-55.555555,-66.666667],[-77.777777,-88.888887,11.111111,22.222222,0,0]]")
+        XCTAssertEqual(query1["insidePolygon"], "[[11.111111,22.222222,33.333333,44.444444,-55.555555,-66.666667],[-77.777777,-88.888887,11.111111,22.222222,0.0,0.0]]")
         let query2 = Query.parse(query1.build())
         XCTAssertEqual(query2.insidePolygon! as NSObject, POLYGONS as NSObject)
     }


### PR DESCRIPTION
When converting Doubles to String we lose precision if we don't use the String() way. If we use the JSONSerializer, everything is converted to Data and then to String which will end with converting 22.2222 to something like 22.22222000000000008