### PR TITLE
Aggregate facets_stats

### DIFF
--- a/Sources/AlgoliaSearch-Client/AbstractClient.swift
+++ b/Sources/AlgoliaSearch-Client/AbstractClient.swift
@@ -270,6 +270,10 @@ internal struct HostStatus {
         // WARNING: `didSet` not called during initialization => we need to update the headers manually here.
         updateHeadersFromAPIKey()
     }
+    
+    deinit {
+        session.finishTasksAndInvalidate()
+    }
 
     /// Set read and write hosts to the same value (convenience method).
     ///

--- a/Sources/AlgoliaSearch-Client/Helpers/DisjunctiveFaceting.swift
+++ b/Sources/AlgoliaSearch-Client/Helpers/DisjunctiveFaceting.swift
@@ -96,6 +96,7 @@ internal class DisjunctiveFaceting {
         }
         // Following answers are just used for their facet counts.
         var disjunctiveFacetCounts = [String: Any]()
+        var facetsStats = [String: Any]()
         for i in 1..<results.count { // for each answer (= each disjunctive facet)
             guard let result = results[i] as? [String: Any], let allFacetCounts = result["facets"] as? [String: [String: Any]] else {
                 throw InvalidJSONError(description:  "Invalid results in response")
@@ -123,8 +124,15 @@ internal class DisjunctiveFaceting {
                     mainContent["exhaustiveFacetsCount"] = false
                 }
             }
+            // Facets stats
+            if let allStats = result["facets_stats"] as? [String: [String: Any]] {
+                for (facetName, stats) in allStats {
+                    facetsStats[facetName] = stats
+                }
+            }
         }
         mainContent["disjunctiveFacets"] = disjunctiveFacetCounts
+        mainContent["facets_stats"] = facetsStats
         return mainContent
     }
     

--- a/Sources/AlgoliaSearch-Client/Helpers/DisjunctiveFaceting.swift
+++ b/Sources/AlgoliaSearch-Client/Helpers/DisjunctiveFaceting.swift
@@ -134,12 +134,6 @@ internal class DisjunctiveFaceting {
                     mainContent["exhaustiveFacetsCount"] = false
                 }
             }
-            // Facets stats
-            if let allStats = result["facets_stats"] as? [String: [String: Any]] {
-                for (facetName, stats) in allStats {
-                    facetsStats[facetName] = stats
-                }
-            }
         }
         mainContent["disjunctiveFacets"] = disjunctiveFacetCounts
         mainContent["facets_stats"] = facetsStats

--- a/Sources/AlgoliaSearch-Client/Helpers/DisjunctiveFaceting.swift
+++ b/Sources/AlgoliaSearch-Client/Helpers/DisjunctiveFaceting.swift
@@ -98,7 +98,7 @@ internal class DisjunctiveFaceting {
         var disjunctiveFacetCounts = [String: Any]()
         var facetsStats = [String: Any]()
         for i in 0..<results.count { // for each answer (= each disjunctive facet)
-            guard let result = results[i] as? [String: Any], let allFacetCounts = result["facets"] as? [String: [String: Any]] else {
+            guard let result = results[i] as? [String: Any] else {
                 throw InvalidJSONError(description:  "Invalid results in response")
             }
             // Facets stats, starts from element 0
@@ -110,6 +110,9 @@ internal class DisjunctiveFaceting {
             // Disjunctive facet should start from element 1
             if i <= 0 {
                 continue
+            }
+            guard let allFacetCounts = result["facets"] as? [String: [String: Any]] else {
+                throw InvalidJSONError(description:  "Invalid results in response")
             }
             // NOTE: Iterating, but there should be just one item.
             for (facetName, facetCounts) in allFacetCounts {

--- a/Sources/AlgoliaSearch-Client/Helpers/DisjunctiveFaceting.swift
+++ b/Sources/AlgoliaSearch-Client/Helpers/DisjunctiveFaceting.swift
@@ -97,9 +97,19 @@ internal class DisjunctiveFaceting {
         // Following answers are just used for their facet counts.
         var disjunctiveFacetCounts = [String: Any]()
         var facetsStats = [String: Any]()
-        for i in 1..<results.count { // for each answer (= each disjunctive facet)
+        for i in 0..<results.count { // for each answer (= each disjunctive facet)
             guard let result = results[i] as? [String: Any], let allFacetCounts = result["facets"] as? [String: [String: Any]] else {
                 throw InvalidJSONError(description:  "Invalid results in response")
+            }
+            // Facets stats, starts from element 0
+            if let allStats = result["facets_stats"] as? [String: [String: Any]] {
+                for (facetName, stats) in allStats {
+                    facetsStats[facetName] = stats
+                }
+            }
+            // Disjunctive facet should start from element 1
+            if i <= 0 {
+                continue
             }
             // NOTE: Iterating, but there should be just one item.
             for (facetName, facetCounts) in allFacetCounts {

--- a/Sources/AlgoliaSearch-Client/Network.swift
+++ b/Sources/AlgoliaSearch-Client/Network.swift
@@ -35,6 +35,7 @@ internal enum HTTPMethod: String {
 /// Only for the sake of unit tests.
 internal protocol URLSession {
     func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask
+    func finishTasksAndInvalidate()
 }
 
 // Convince the compiler that NSURLSession does implements our custom protocol.
@@ -129,6 +130,10 @@ internal class URLSessionLogger: NSObject, URLSession {
         }
         task.addObserver(self, forKeyPath: "state", options: .new, context: nil)
         return task
+    }
+    
+    func finishTasksAndInvalidate() {
+        session.finishTasksAndInvalidate()
     }
     
     override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {

--- a/Tests/Helpers/MockURLSession.swift
+++ b/Tests/Helpers/MockURLSession.swift
@@ -74,6 +74,7 @@ public struct MockResponse {
 /// A replacement for `NSURLSession` used for mocking network requests.
 ///
 public class MockURLSession: AlgoliaSearch.URLSession {
+    
     /// Predefined set of responses for the specified URLs.
     public var responses: [String: MockResponse] = [String: MockResponse]()
     
@@ -87,6 +88,10 @@ public class MockURLSession: AlgoliaSearch.URLSession {
         let task = MockURLSessionDataTask(request: request, details: details, completionHandler: completionHandler)
         task.cancellable = self.cancellable
         return task
+    }
+    
+    public func finishTasksAndInvalidate() {
+        // do nothing
     }
 }
 

--- a/Tests/Integration Tests/IndexTests.swift
+++ b/Tests/Integration Tests/IndexTests.swift
@@ -868,6 +868,10 @@ class IndexTests: OnlineTestCase {
       XCTAssertEqual(brandFacetCounts!["Apple"] as? Int, 2)
       XCTAssertEqual(brandFacetCounts!["Samsung"] as? Int, 1)
       XCTAssertEqual(brandFacetCounts!["Whatever"] as? Int, 1)
+      let facetsStats = content["facets_stats"] as? [String: [String: Any]]
+      let starStats = facetsStats!["stars"]
+      XCTAssertEqual(starStats!["max"] as? Int, 5)
+      XCTAssertEqual(starStats!["min"] as? Int, 4)
     }
     
     self.waitForExpectations(timeout: expectationTimeout, handler: nil)


### PR DESCRIPTION
In InstantSearch-Core-Swift project, I find that `content["facets_stats"]` in `SearchResults` class is always `nil`. After debugging with some break points, I found the function `_aggregateResults` in `DisjunctiveFaceting` class. It is in this function we construct `content` dictionary mentioned above, and it is in this function we lose all facet stats values. So in addition to aggregate all values under `"facets"` key from the raw json response, we should also aggregate all values under `"facets_stats"` key.