### PR TITLE
Fix crash in AsyncOperation & backed up OperationQueue

### DIFF
--- a/Sources/AlgoliaSearch-Client/AsyncOperation.swift
+++ b/Sources/AlgoliaSearch-Client/AsyncOperation.swift
@@ -82,11 +82,6 @@ internal class AsyncOperation: Operation {
     return _cancelled
   }
 
-  override func cancel() {
-    _cancelled = true
-    finish()
-  }
-
   /// Mark the operation as finished.
   func finish() {
     _executing = false

--- a/Sources/AlgoliaSearch-Client/AsyncOperation.swift
+++ b/Sources/AlgoliaSearch-Client/AsyncOperation.swift
@@ -82,11 +82,6 @@ internal class AsyncOperation: Operation {
     return _cancelled
   }
 
-  override func start() {
-    assert(!_executing)
-    _executing = true
-  }
-
   override func cancel() {
     _cancelled = true
     finish()


### PR DESCRIPTION
Summary
===

**Problem 1:**
We were having the same crash from #592 appearing in our logs. A fix was attempted in #593, but was ultimately never merged in.

**Problem 2:**
We were running into an issue where the `OperationQueue` was being backed up _(with up to several hundred operations)_ when calling `cancel()` on requests, such that any new subsequent requests would never be made.

Result
===

The solution we came up with involves removing the overridden `start()` and `cancel()` methods within `AsyncOperation`—and letting its superclass take care of its implementation. This fixes both the crash and the queue being backed up. Not entirely sure why these were overridden with a custom implementation to begin with, since they don’t seem to adhere to the recommendations made by Apple when subclassing `Operation`.

According to the [Apple Documentation for `Operation`](https://developer.apple.com/documentation/foundation/operation#1673799):
> **Subclassing Notes**
> The `NSOperation` class provides the basic logic to track the execution state of your operation but otherwise must be subclassed to do any real work.
>
> **Methods to Override**
> For non-concurrent operations, you typically override only one method:
> - `main()`

Of course, this Pull Request breaks the existing cancel unit tests you guys have because now it behaves slightly differently than what the tests were testing for, but we fixed both a crash _and_ an edge case where requests would never be executed _(due to the queue being backed up)_, so we think it’s worthwhile. 🙂

_Credits go to @handokochen for finding the proper fix to both!_