### PR TITLE
Exclude CoreTelephony dependent code from Mac Catalyst app

### DIFF
--- a/Sources/AlgoliaSearch-Client/Network.swift
+++ b/Sources/AlgoliaSearch-Client/Network.swift
@@ -41,7 +41,7 @@ internal protocol URLSession {
 // Convince the compiler that NSURLSession does implements our custom protocol.
 extension Foundation.URLSession: URLSession {}
 
-#if os(iOS) && DEBUG
+#if os(iOS) && DEBUG && !targetEnvironment(macCatalyst)
 
   import CoreTelephony
   import SystemConfiguration

--- a/Sources/AlgoliaSearch-Client/Version.swift
+++ b/Sources/AlgoliaSearch-Client/Version.swift
@@ -1,4 +1,4 @@
 // This is generated file. Don't modify it manually.
 public struct Version {
-  public static let current = "7.0.2"
+  public static let current = "7.0.3"
 }


### PR DESCRIPTION
This fix addresses the [issue ](https://github.com/algolia/instantsearch-core-swift/issues/103) making impossible the usage of Swift Client for universal Catalyst app development starting from Xcode 11.4