### PR TITLE
feat(Settings): Accept `enablePersonalization` boolean as a valid setting parameter

### DIFF
--- a/Sources/AlgoliaSearchClient/Models/Settings/Settings+Codable.swift
+++ b/Sources/AlgoliaSearchClient/Models/Settings/Settings+Codable.swift
@@ -43,6 +43,7 @@ extension Settings {
     case keepDiacriticsOnCharacters
     case queryLanguages
     case enableRules
+    case enablePersonalization
     case queryType
     case removeWordsIfNoResults
     case advancedSyntax

--- a/Sources/AlgoliaSearchClient/Models/Settings/Settings.swift
+++ b/Sources/AlgoliaSearchClient/Models/Settings/Settings.swift
@@ -227,6 +227,13 @@ public struct Settings: Codable {
    - [Documentation](https://www.algolia.com/doc/api-reference/api-parameters/enableRules/?language=swift)
    */
   public var enableRules: Bool?
+  
+  /**
+   Enable the Personalization feature.
+   - Engine default: false
+   - [Documentation][https://www.algolia.com/doc/api-reference/api-parameters/enablePersonalization/?language=swift]
+   */
+  public var enablePersonalization: Bool?
 
   /**
    Controls if and how query words are interpreted as [prefixes][https://www.algolia.com/doc/guides/textual-relevance/prefix-search/?language=swift).

--- a/Tests/AlgoliaSearchClientTests/Misc/Settings.json
+++ b/Tests/AlgoliaSearchClientTests/Misc/Settings.json
@@ -18,6 +18,7 @@
   "paginationLimitedTo": 1000,
   "attributeForDistinct": null,
   "exactOnSingleWordQuery": "attribute",
+  "enablePersonalization": true,
   "ranking": [
     "typo",
     "geo",

--- a/Tests/AlgoliaSearchClientTests/Unit/Settings/SettingsTests.swift
+++ b/Tests/AlgoliaSearchClientTests/Unit/Settings/SettingsTests.swift
@@ -17,7 +17,7 @@ class SettingsTests: XCTestCase {
     settings.sortFacetsBy = .count
     settings.attributesToHighlight = ["attr2", "attr3"]
     settings.attributeCriteriaComputedByMinProximity = false
-    
+    settings.enablePersonalization = true
   }
 
   func testDecoding() throws {
@@ -25,5 +25,6 @@ class SettingsTests: XCTestCase {
     let decoder = JSONDecoder()
     let settings = try decoder.decode(Settings.self, from: data)
     XCTAssertEqual(settings.attributeCriteriaComputedByMinProximity, false)
+    XCTAssertEqual(settings.enablePersonalization, true)
   }
 }


### PR DESCRIPTION
Resolves #639 