### PR TITLE
fix(personalization_strategy): prevent error in CTS personalization test on 429 HTTP code

### DIFF
--- a/Sources/AlgoliaSearchClient/Command/Command+Personalization.swift
+++ b/Sources/AlgoliaSearchClient/Command/Command+Personalization.swift
@@ -31,6 +31,8 @@ extension Command {
       let requestOptions: RequestOptions?
 
       init(strategy: PersonalizationStrategy, requestOptions: RequestOptions?) {
+        var requestOptions = requestOptions.unwrapOrCreate()
+        requestOptions.setHeader("application/json", forKey: .contentType)
         self.requestOptions = requestOptions
         self.urlRequest = .init(method: .post, path: .strategies >>> PersonalizationRoute.personalization, body: strategy.httpBody, requestOptions: self.requestOptions)
       }

--- a/Sources/AlgoliaSearchClient/Models/Internal/HTTP/HTTPStatusCode.swift
+++ b/Sources/AlgoliaSearchClient/Models/Internal/HTTP/HTTPStatusCode.swift
@@ -13,6 +13,7 @@ extension HTTPStatusСode {
 
   static let notFound: HTTPStatusСode = 404
   static let requestTimeout: HTTPStatusСode = 408
+  static let tooManyRequests: HTTPStatusСode = 429
 
   func belongs(to categories: HTTPStatusCategory...) -> Bool {
     return categories.map { $0.contains(self) }.contains(true)

--- a/Tests/AlgoliaSearchClientTests/Integration/PersonalizationIntegrationTests.swift
+++ b/Tests/AlgoliaSearchClientTests/Integration/PersonalizationIntegrationTests.swift
@@ -12,12 +12,41 @@ import XCTest
 class PersonalizationIntegrationTests: OnlineTestCase {
   
   override var retryableTests: [() throws -> Void] {
-    [personalization]
+    [
+     getStrategy,
+     setStrategy
+    ]
   }
 
-  func personalization() throws {
+  func getStrategy() throws {
     let recommendationClient = RecommendationClient(appID: client.applicationID, apiKey: client.apiKey, region: .custom("eu"))
     let _ = try recommendationClient.getPersonalizationStrategy()
+  }
+  
+  func setStrategy() throws {
+    
+    let recommendationClient = RecommendationClient(appID: client.applicationID, apiKey: client.apiKey, region: .custom("us"))
+
+    let strategy = PersonalizationStrategy(
+      eventsScoring: [
+        .init(eventName: "Add to cart", eventType: .conversion, score: 50),
+        .init(eventName: "Purchase", eventType: .conversion, score: 100)
+      ],
+      facetsScoring: [
+        .init(facetName: "brand", score: 100),
+        .init(facetName: "categories", score: 10)
+      ],
+      personalizationImpact: 0
+    )
+
+    do {
+      try recommendationClient.setPersonalizationStrategy(strategy)
+    } catch let httpError as HTTPError where httpError.statusCode == HTTPStatusСode.tooManyRequests {
+      // The personalization API is now limiting the number of setPersonalizationStrategy()` successful calls
+      // to 15 per day. If the 429 error is returned, the response is considered a "success".
+    } catch let error {
+      throw error
+    }
   }
   
 }

--- a/Tests/AlgoliaSearchClientTests/Unit/Command/PersonalizationCommandTests.swift
+++ b/Tests/AlgoliaSearchClientTests/Unit/Command/PersonalizationCommandTests.swift
@@ -34,6 +34,7 @@ class PersonalizationCommandTests: XCTestCase, AlgoliaCommandTest {
               .init(name: "testParameter", value: "testParameterValue"),
           ],
           body: test.personalizationStrategy.httpBody,
+          additionalHeaders: ["Content-Type": "application/json"],
           requestOptions: test.requestOptions)
   }
   


### PR DESCRIPTION
The personalization API is now limiting the number of setPersonalizationStrategy() successful calls
to 15 per day. If the 429 error is returned, the response is considered a success.

Fixes: #647