### PR TITLE
Add explicit percent encoding for plus sign for the browsing cursor

### DIFF
--- a/Sources/AlgoliaSearchClient/Command/Command+Search.swift
+++ b/Sources/AlgoliaSearchClient/Command/Command+Search.swift
@@ -40,7 +40,7 @@ extension Command {
       }
 
       init(indexName: IndexName, cursor: Cursor? = nil, requestOptions: RequestOptions?) {
-        self.requestOptions = requestOptions.updateOrCreate(cursor.flatMap { [.cursor: $0.rawValue] } ?? [:])
+        self.requestOptions = requestOptions.updateOrCreate(cursor.flatMap { [.cursor: $0.rawValue.addingPercentEncoding(withAllowedCharacters: .uriAllowed)] } ?? [:])
         let path = .indexesV1 >>> .index(indexName) >>> IndexCompletion.browse
         urlRequest = .init(method: .get, path: path, requestOptions: self.requestOptions)
       }

--- a/Sources/AlgoliaSearchClient/Transport/URLSession/URLRequest+Convenience.swift
+++ b/Sources/AlgoliaSearchClient/Transport/URLSession/URLRequest+Convenience.swift
@@ -11,7 +11,7 @@ extension URLRequest: Builder {}
 
 extension CharacterSet {
   
-  static var uriAllowed = CharacterSet.alphanumerics.union(.init(charactersIn: "-_.!~*'()"))
+  static var uriAllowed = CharacterSet.urlQueryAllowed.subtracting(.init(charactersIn: "+"))
   
 }
 
@@ -36,15 +36,7 @@ extension URLRequest {
     urlComponents.path = path.fullPath
   
     if let urlParameters = requestOptions?.urlParameters {
-      urlComponents.queryItems = urlParameters
-        .map { (key, value) in
-          guard let encodedName = key.rawValue.addingPercentEncoding(withAllowedCharacters: .uriAllowed) else {
-            return nil
-          }
-          let encodedValue = value?.addingPercentEncoding(withAllowedCharacters: .uriAllowed)
-          return URLQueryItem(name: encodedName, value: encodedValue)
-        }
-        .compactMap { $0 }
+      urlComponents.queryItems = urlParameters.map { (key, value) in .init(name: key.rawValue, value: value) }
     }
 
     var request = URLRequest(url: urlComponents.url!)

--- a/Tests/AlgoliaSearchClientTests/Unit/Command/SearchCommandTests.swift
+++ b/Tests/AlgoliaSearchClientTests/Unit/Command/SearchCommandTests.swift
@@ -39,7 +39,7 @@ class SearchCommandTests: XCTestCase, AlgoliaCommandTest {
           callType: .read,
           method: .get,
           urlPath: "/1/indexes/testIndex/browse",
-          queryItems: [.init(name: "testParameter", value: "testParameterValue"), .init(name: "cursor", value: "AgA%2BBgg4MTUyNTQ0Mg%3D%3D")],
+          queryItems: [.init(name: "testParameter", value: "testParameterValue"), .init(name: "cursor", value: "AgA%2BBgg4MTUyNTQ0Mg==")],
           body: nil,
           requestOptions: test.requestOptions)
   }

--- a/Tests/AlgoliaSearchClientTests/Unit/Command/SearchCommandTests.swift
+++ b/Tests/AlgoliaSearchClientTests/Unit/Command/SearchCommandTests.swift
@@ -39,7 +39,7 @@ class SearchCommandTests: XCTestCase, AlgoliaCommandTest {
           callType: .read,
           method: .get,
           urlPath: "/1/indexes/testIndex/browse",
-          queryItems: [.init(name: "testParameter", value: "testParameterValue"), .init(name: "cursor", value: "testCursor")],
+          queryItems: [.init(name: "testParameter", value: "testParameterValue"), .init(name: "cursor", value: "AgA%2BBgg4MTUyNTQ0Mg%3D%3D")],
           body: nil,
           requestOptions: test.requestOptions)
   }

--- a/Tests/AlgoliaSearchClientTests/Unit/TestValues.swift
+++ b/Tests/AlgoliaSearchClientTests/Unit/TestValues.swift
@@ -28,7 +28,7 @@ struct TestValues {
   }()
   let taskID: TaskID = "testTaskID"
   let requestOptions = RequestOptions(headers: ["testHeader": "testHeaderValue"], urlParameters: ["testParameter": "testParameterValue"])
-  let cursor: Cursor = "testCursor"
+  let cursor: Cursor = "AgA+Bgg4MTUyNTQ0Mg=="
   let userID: UserID = "testUserID"
   let clusterName: ClusterName = "testClusterName"
   


### PR DESCRIPTION
This PR implements the explicit percent encoding for plus sign for browse cursor, lack of which causes browse call error. 