### PR TITLE
Fix retry strategy behaviour if all the hosts are unreachable

### DIFF
--- a/Sources/AlgoliaSearchClient/Transport/HTTP/HTTPRequestBuilder.swift
+++ b/Sources/AlgoliaSearchClient/Transport/HTTP/HTTPRequestBuilder.swift
@@ -27,15 +27,22 @@ class HTTPRequestBuilder {
   func build<Response: Decodable, Output>(for command: AlgoliaCommand, transform: @escaping (Response) -> Output, with completion: @escaping (HTTPRequest<Response, Output>.Result) -> Void) -> HTTPRequest<Response, Output> {
 
     let timeout = command.requestOptions?.timeout(for: command.callType) ?? configuration.timeout(for: command.callType)
-    let hostIterator = HostIterator(retryStrategy: retryStrategy, callType: command.callType)
     var request = command.urlRequest.setIfNotNil(\.credentials, to: credentials)
     let userAgentsValue = UserAgentController.userAgents.map(\.description).joined(separator: "; ")
     request.addValue(userAgentsValue, forHTTPHeaderField: HTTPHeaderKey.userAgent.rawValue)
-    return HTTPRequest(requester: requester, retryStrategy: retryStrategy, hostIterator: hostIterator, request: request, timeout: timeout, transform: transform, completion: completion)
+    return HTTPRequest(requester: requester,
+                       retryStrategy: retryStrategy,
+                       request: request,
+                       callType: command.callType,
+                       timeout: timeout,
+                       transform: transform,
+                       completion: completion)
   }
 
   func build<Response: Decodable, Output>(for command: AlgoliaCommand, transform: @escaping (Response) -> Output, responseType: Output.Type) -> HTTPRequest<Response, Output> {
-    return build(for: command, transform: transform, with: { (_:HTTPRequest<Response, Output>.Result) in })
+    return build(for: command,
+                 transform: transform,
+                 with: { (_:HTTPRequest<Response, Output>.Result) in })
   }
 
 }

--- a/Sources/AlgoliaSearchClient/Transport/HTTP/HTTPTransport+Error.swift
+++ b/Sources/AlgoliaSearchClient/Transport/HTTP/HTTPTransport+Error.swift
@@ -9,9 +9,21 @@ import Foundation
 
 extension HTTPTransport {
 
-  enum Error: Swift.Error {
+  enum Error: Swift.Error, LocalizedError {
     case noReachableHosts
     case missingData
+    case decodingFailure(Swift.Error)
+    
+    var localizedDescription: String {
+      switch self {
+      case .noReachableHosts:
+        return "All hosts are unreachable"
+      case .missingData:
+        return "Missing response data"
+      case .decodingFailure:
+        return "Response decoding failed"
+      }
+    }
   }
 
 }

--- a/Sources/AlgoliaSearchClient/Transport/HTTP/HTTPTransport+Result.swift
+++ b/Sources/AlgoliaSearchClient/Transport/HTTP/HTTPTransport+Result.swift
@@ -32,7 +32,7 @@ extension Result where Success: Decodable, Failure == Error {
       let object = try jsonDecoder.decode(Success.self, from: data)
       self = .success(object)
     } catch let error {
-      self = .failure(error)
+      self = .failure(HTTPTransport.Error.decodingFailure(error))
     }
 
   }

--- a/Sources/AlgoliaSearchClient/Transport/RetryStrategy/HostIterator.swift
+++ b/Sources/AlgoliaSearchClient/Transport/RetryStrategy/HostIterator.swift
@@ -9,16 +9,14 @@ import Foundation
 
 class HostIterator: IteratorProtocol {
 
-  var retryStrategy: RetryStrategy
-  let callType: CallType
-
-  init(retryStrategy: RetryStrategy, callType: CallType) {
-    self.retryStrategy = retryStrategy
-    self.callType = callType
+  var getHost: () -> RetryableHost?
+  
+  init(getHost: @escaping () -> RetryableHost?) {
+    self.getHost = getHost
   }
 
   func next() -> RetryableHost? {
-    return retryStrategy.host(for: callType)
+    return getHost()
   }
 
 }

--- a/Sources/AlgoliaSearchClient/Transport/RetryStrategy/RetryStrategy.swift
+++ b/Sources/AlgoliaSearchClient/Transport/RetryStrategy/RetryStrategy.swift
@@ -9,7 +9,7 @@ import Foundation
 
 protocol RetryStrategy: class {
 
-  func host(for callType: CallType) -> RetryableHost?
+  func retryableHosts(for callType: CallType) -> HostIterator
   func notify<T>(host: RetryableHost, result: Result<T, Swift.Error>) -> RetryOutcome<T>
 
 }

--- a/Sources/AlgoliaSearchClient/Transport/RetryStrategy/RetryStrategy.swift
+++ b/Sources/AlgoliaSearchClient/Transport/RetryStrategy/RetryStrategy.swift
@@ -7,10 +7,6 @@
 
 import Foundation
 
-protocol HostResultNotifiable {
-
-}
-
 protocol RetryStrategy: class {
 
   func host(for callType: CallType) -> RetryableHost?


### PR DESCRIPTION
**Summary**

This PR fixes the implementation of the retry strategy. 

Previously after finishing the hosts iteration, the strategy reset the hosts and started the polling again.
It led to infinite host polling loop and no error occured in case of missing internet connection, for example.    

**Result**

With the fixes applied in this PR, the retry strategy iterates the host list only once per request.  

Fixes #664 