### PR TITLE
Updated min ios version and log version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "AlgoliaSearchClient",
     platforms: [
-        .iOS(.v8),
+        .iOS(.v9),
         .macOS(.v10_10),
         .watchOS(.v2),
         .tvOS(.v9)
@@ -17,7 +17,7 @@ let package = Package(
             targets: ["AlgoliaSearchClient"])
     ],
     dependencies: [
-        .package(url:"https://github.com/apple/swift-log.git", from: "1.3.0")
+        .package(url:"https://github.com/apple/swift-log.git", from: "1.4.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

After trying to use the Algolia Search Client with SPM, I've noticed that for some reason, the dependency of the Logging (https://github.com/apple/swift-log) is not fully satisfied the targeting the min iOS version to 8.0. To fix the problem, we should update the min version to at least 9.0. I've also update the log version to 1.4.0 since it doesn't introduce any bugs.

**Result**

Nothing in special, you should be able to download the lib via SPM and build your project without problems.

