### PR TITLE
fix(Browse): change browse with cursor method GET -> POST 

### DIFF
--- a/AlgoliaSearchClient.podspec
+++ b/AlgoliaSearchClient.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name         = "AlgoliaSearchClient"
   spec.module_name  = 'AlgoliaSearchClient'
-  spec.version      = "8.1.1"
+  spec.version      = "8.1.2-beta.1"
   spec.summary      = "Algolia Search API Client written in Swift."
   spec.homepage     = "https://github.com/algolia/algoliasearch-client-swift"
   spec.license      = { :type => "MIT", :file => "LICENSE" }

--- a/Sources/AlgoliaSearchClient/Command/Command+Search.swift
+++ b/Sources/AlgoliaSearchClient/Command/Command+Search.swift
@@ -39,9 +39,9 @@ extension Command {
         urlRequest = .init(method: .post, path: path, body: query.httpBody, requestOptions: requestOptions)
       }
 
-      init(indexName: IndexName, cursor: Cursor? = nil, requestOptions: RequestOptions?) {
+      init(indexName: IndexName, cursor: Cursor, requestOptions: RequestOptions?) {
         self.requestOptions = requestOptions
-        let body = cursor.flatMap(CursorWrapper.init)
+        let body = CursorWrapper(cursor)
         let path = .indexesV1 >>> .index(indexName) >>> IndexCompletion.browse
         urlRequest = .init(method: .post, path: path, body: body.httpBody, requestOptions: self.requestOptions)
       }

--- a/Sources/AlgoliaSearchClient/Command/Command+Search.swift
+++ b/Sources/AlgoliaSearchClient/Command/Command+Search.swift
@@ -40,9 +40,10 @@ extension Command {
       }
 
       init(indexName: IndexName, cursor: Cursor? = nil, requestOptions: RequestOptions?) {
-        self.requestOptions = requestOptions.updateOrCreate(cursor.flatMap { [.cursor: $0.rawValue.addingPercentEncoding(withAllowedCharacters: .uriAllowed)] } ?? [:])
+        self.requestOptions = requestOptions
+        let body = cursor.flatMap(CursorWrapper.init)
         let path = .indexesV1 >>> .index(indexName) >>> IndexCompletion.browse
-        urlRequest = .init(method: .get, path: path, requestOptions: self.requestOptions)
+        urlRequest = .init(method: .post, path: path, body: body.httpBody, requestOptions: self.requestOptions)
       }
 
     }

--- a/Sources/AlgoliaSearchClient/Helpers/Version+Current.swift
+++ b/Sources/AlgoliaSearchClient/Helpers/Version+Current.swift
@@ -1,2 +1,2 @@
 // This is generated file. Don't modify it manually.
-public extension Version { static let current: Version = .init(major: 8, minor: 1, patch: 1, prereleaseIdentifier: nil) }
+public extension Version { static let current: Version = .init(major: 8, minor: 1, patch: 2, prereleaseIdentifier: "beta.1") }

--- a/Sources/AlgoliaSearchClient/Index/Index+Search.swift
+++ b/Sources/AlgoliaSearchClient/Index/Index+Search.swift
@@ -107,7 +107,7 @@ public extension Index {
    - Parameter completion: Result completion
    - Returns: SearchResponse object
    */
-  @discardableResult func browse(query: Query,
+  @discardableResult func browse(query: Query = .init(),
                                  requestOptions: RequestOptions? = nil,
                                  completion: @escaping ResultCallback<SearchResponse>) -> Operation & TransportTask {
     let command = Command.Search.Browse(indexName: name, query: query, requestOptions: requestOptions)
@@ -122,7 +122,7 @@ public extension Index {
    - Parameter completion: Result completion
    - Returns: Launched asynchronous operation
    */
-  @discardableResult func browse(query: Query,
+  @discardableResult func browse(query: Query = .init(),
                                  requestOptions: RequestOptions? = nil) throws -> SearchResponse {
     let command = Command.Search.Browse(indexName: name, query: query, requestOptions: requestOptions)
     return try execute(command)
@@ -137,7 +137,7 @@ public extension Index {
    - Parameter completion: Result completion
    - Returns: Launched asynchronous operation
    */
-  @discardableResult func browse(cursor: Cursor? = nil,
+  @discardableResult func browse(cursor: Cursor,
                                  requestOptions: RequestOptions? = nil,
                                  completion: @escaping ResultCallback<SearchResponse>) -> Operation & TransportTask {
     let command = Command.Search.Browse(indexName: name, cursor: cursor, requestOptions: requestOptions)
@@ -152,7 +152,7 @@ public extension Index {
    - Parameter requestOptions: Configure request locally with RequestOptions.
    - Returns: SearchResponse object
    */
-  @discardableResult func browse(cursor: Cursor? = nil,
+  @discardableResult func browse(cursor: Cursor,
                                  requestOptions: RequestOptions? = nil) throws -> SearchResponse {
     let command = Command.Search.Browse(indexName: name, cursor: cursor, requestOptions: requestOptions)
     return try execute(command)

--- a/Sources/AlgoliaSearchClient/Models/Data structures/FieldWrapper.swift
+++ b/Sources/AlgoliaSearchClient/Models/Data structures/FieldWrapper.swift
@@ -37,6 +37,7 @@ struct EditsKey: Key { static let value = "edits" }
 struct ObjectIDKey: Key { static let value = "objectID" }
 struct RemoveKey: Key { static let value = "remove" }
 struct ClusterKey: Key { static let value = "cluster" }
+struct CursorKey: Key { static let value = "cursor" }
 
 typealias ParamsWrapper<Wrapped: Codable> = FieldWrapper<ParamsKey, Wrapped>
 typealias RequestsWrapper<Wrapped: Codable> = FieldWrapper<RequestsKey, Wrapped>
@@ -44,3 +45,4 @@ typealias EventsWrapper<Wrapped: Codable> = FieldWrapper<EventsKey, Wrapped>
 typealias EditsWrapper = FieldWrapper<EditsKey, [Rule.Edit]>
 typealias ObjectIDWrapper = FieldWrapper<ObjectIDKey, ObjectID>
 typealias ClusterWrapper<Wrapped: Codable> = FieldWrapper<ClusterKey, Wrapped>
+typealias CursorWrapper = FieldWrapper<CursorKey, Cursor>

--- a/Tests/AlgoliaSearchClientTests/Integration/BrowseIntegrationTests.swift
+++ b/Tests/AlgoliaSearchClientTests/Integration/BrowseIntegrationTests.swift
@@ -35,11 +35,12 @@ class BrowseIntegrationTests: OnlineTestCase {
       let objectID: String
       let name: String
     }
-    
-    let records: [Record] = (0...50).map { _ in
-      .init(objectID: .random(length: 5), name: String.random(length: .random(in: 1...20)))
+        
+    let records: [Record] = (0...10000).map { _ in
+        .init(objectID: .random(length: 5), name: String.random(length: .random(in: 1...20)))
     }
     
+    try index.setSettings(Settings().set(\.attributesForFaceting, to: ["metric", "color"]))
     try index.saveObjects(records).wait()
     
     let responses = try index.browseObjects()

--- a/Tests/AlgoliaSearchClientTests/Unit/Command/SearchCommandTests.swift
+++ b/Tests/AlgoliaSearchClientTests/Unit/Command/SearchCommandTests.swift
@@ -37,7 +37,7 @@ class SearchCommandTests: XCTestCase, AlgoliaCommandTest {
     let command = Command.Search.Browse(indexName: test.indexName, cursor: test.cursor, requestOptions: test.requestOptions)
     check(command: command,
           callType: .read,
-          method: .get,
+          method: .post,
           urlPath: "/1/indexes/testIndex/browse",
           queryItems: [.init(name: "testParameter", value: "testParameterValue")],
           body: CursorWrapper(test.cursor).httpBody,

--- a/Tests/AlgoliaSearchClientTests/Unit/Command/SearchCommandTests.swift
+++ b/Tests/AlgoliaSearchClientTests/Unit/Command/SearchCommandTests.swift
@@ -39,8 +39,8 @@ class SearchCommandTests: XCTestCase, AlgoliaCommandTest {
           callType: .read,
           method: .get,
           urlPath: "/1/indexes/testIndex/browse",
-          queryItems: [.init(name: "testParameter", value: "testParameterValue"), .init(name: "cursor", value: "AgA%2BBgg4MTUyNTQ0Mg==")],
-          body: nil,
+          queryItems: [.init(name: "testParameter", value: "testParameterValue")],
+          body: CursorWrapper(test.cursor).httpBody,
           requestOptions: test.requestOptions)
   }
 


### PR DESCRIPTION
**Summary**

This PR changes the HTTP method of the browse with cursor call from GET to POST.
It makes Swift API client aligned with other strongly typed clients such as Java and C# clients avoiding ussues with encoding the cursor as an URL parameter.

Resolves #675