### PR TITLE
fix: set ABTestResponse.Variant.averageClickPosition type `Double` 

### DIFF
--- a/Sources/AlgoliaSearchClient/Models/Analytics/ABTest/Response/ABTestResponse+Variant.swift
+++ b/Sources/AlgoliaSearchClient/Models/Analytics/ABTest/Response/ABTestResponse+Variant.swift
@@ -29,7 +29,7 @@ extension ABTestResponse {
     public let noResultCount: Int?
 
     /// Average click position for the variant.
-    public let averageClickPosition: Int?
+    public let averageClickPosition: Double?
 
     public let searchCount: Int?
 


### PR DESCRIPTION
**Summary**

Resolves [this issue](https://github.com/algolia/algoliasearch-client-specs-internal/issues/143)