### PR TITLE
fix: Set tag parsing for highlighted strings diacritic insensitive

### DIFF
--- a/Sources/AlgoliaSearchClient/Models/Search/Response/SearchResponse/Auxiliary/Highlighting/HighlightedString.swift
+++ b/Sources/AlgoliaSearchClient/Models/Search/Response/SearchResponse/Auxiliary/Highlighting/HighlightedString.swift
@@ -15,7 +15,7 @@ public struct HighlightedString: Codable, Hashable {
   public let taggedString: TaggedString
 
   public init(string: String) {
-    self.taggedString = TaggedString(string: string, preTag: HighlightedString.preTag, postTag: HighlightedString.postTag, options: [.caseInsensitive])
+    self.taggedString = TaggedString(string: string, preTag: HighlightedString.preTag, postTag: HighlightedString.postTag, options: [.caseInsensitive, .diacriticInsensitive])
   }
 
   public init(from decoder: Decoder) throws {

--- a/Tests/AlgoliaSearchClientTests/Unit/HighlightedStringTests.swift
+++ b/Tests/AlgoliaSearchClientTests/Unit/HighlightedStringTests.swift
@@ -33,6 +33,26 @@ class HighlightedStringTests: XCTestCase {
       XCTAssertEqual(expectedHighlightedPart, extractHighlightedPart(from: decodedHighlighted))
 
     }
+  
+  func testDiacritic() throws {
+    let input = """
+    Le 30 octobre, un concert de musiques gaéliques irlandaises <ém>e</ëm>t <em>é</em>cossaises <em>e</em>st au programme. À travers de nombreux airs, pour la plupart de compositeurs inconnus ou anonymes, The Curious Bards vous feront découvrir leur « livre de chevet musical » ; ces collections d’airs, propres aux musiciens itinérants du XVIIe <em>e</em>t XVIIIe siècle <em>e</em>n <em>Irlande</em> <em>e</em>t <em>e</em>n <em>E</em>́cosse, ils vous amèneront au plus près de l’âme celte <em>e</em>t gaélique. L’<èm>e</em>nsemble sera composé d’Alix Boivert, violon baroque, Sarah Van Oudenhove, viole de gambe, Bruno Harlé, flûtes, Louis Capeille, harpe, <em>e</em>t Jean-Christophe Morel, cistre. Vendredi 30 octobre, à 20 h 30, à la Maison de la culture <êm>e</em>t des loisirs. Tarifs : plein 15 <em>€</em>́ ; réduit 10 <em>€</em>.
+    """
+    
+    let highlightedString = HighlightedString(string: input)
+    
+    let taggedRanges = highlightedString.taggedString.taggedRanges
+    let output = highlightedString.taggedString.output
+    let highlightedStrings: [String] = taggedRanges.map { output[$0] }.map(String.init)
+    
+    let expectedHighlightedStrings = [
+      "e", "é", "e", "e", "e", "Irlande", "e", "e", "E", "e", "e", "e", "e", "€", "€"
+    ]
+    
+    XCTAssertEqual(highlightedStrings, expectedHighlightedStrings)
+    
+  }
+
 
 }
 


### PR DESCRIPTION
**Summary**

Set highlighting tag parsing diacritic insensitive to avoid crashes while calculating highlighted subranges. 