### PR TITLE
ci: remove check of the branch name and its cleanliness for Bitrise in depolyment script

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -49,10 +49,13 @@ lane :deploy do |options|
   podspec_path = "AlgoliaSearchClient.podspec"
   base_branch = options[:branch] || "master"
 
-  ensure_git_branch(
-    branch: base_branch
-  )
-  ensure_git_status_clean
+  # ensure branch and cleaniness locally but not on Bitrise.
+  if !ENV['BITRISE_BUILD_NUMBER'] 
+    ensure_git_branch(
+      branch: base_branch
+    )
+    ensure_git_status_clean
+  end
 
   release_type = options[:type]
 


### PR DESCRIPTION
**Summary**

Set the check of the branch name and its cleanliness for Bitrise as it works with detached HEAD state.