### PR TITLE
fix: HostIterator crash

### DIFF
--- a/Sources/AlgoliaSearchClient/Transport/RetryStrategy/AlgoliaRetryStrategy.swift
+++ b/Sources/AlgoliaSearchClient/Transport/RetryStrategy/AlgoliaRetryStrategy.swift
@@ -37,7 +37,10 @@ class AlgoliaRetryStrategy: RetryStrategy {
       }
 
       return HostIterator { [weak self] in
-        self?.hosts.first { $0.supports(callType) && $0.isUp }
+        guard let retryStrategy = self else { return nil }
+        return retryStrategy.queue.sync {
+          return retryStrategy.hosts.first { $0.supports(callType) && $0.isUp }
+        }
       }
     }
   }


### PR DESCRIPTION
**Summary**

This fix adds synchronisation to HostIterator callback provided by retry strategy to avoid crash due to concurrent access to the list of hosts
Fixes #705 