### PR TITLE
fix: Missing content-type header for async InsightsClient.sendEvents call

### DIFF
--- a/Sources/AlgoliaSearchClient/Client/InsightsClient.swift
+++ b/Sources/AlgoliaSearchClient/Client/InsightsClient.swift
@@ -108,9 +108,6 @@ public extension InsightsClient {
    - Returns: JSON  object
    */
   @discardableResult func sendEvents(_ events: [InsightsEvent], requestOptions: RequestOptions? = nil) throws -> Empty {
-    var updatedRequestOptions = requestOptions ?? .init()
-    updatedRequestOptions.setHeader("application/json", forKey: .contentType)
-    let requestOptions = updatedRequestOptions
     let command = Command.Insights.SendEvents(events: events, requestOptions: requestOptions)
     return try execute(command)
   }

--- a/Sources/AlgoliaSearchClient/Command/Command+Insights.swift
+++ b/Sources/AlgoliaSearchClient/Command/Command+Insights.swift
@@ -22,7 +22,9 @@ extension Command {
 
       init(events: [InsightsEvent], requestOptions: RequestOptions?) {
         let body = EventsWrapper(events)
-        self.requestOptions = requestOptions
+        var updatedRequestOptions = requestOptions ?? .init()
+        updatedRequestOptions.setHeader("application/json", forKey: .contentType)
+        self.requestOptions = updatedRequestOptions
         self.urlRequest = .init(method: .post, path: Path.eventsV1, body: body.httpBody, requestOptions: self.requestOptions)
       }
 

--- a/Sources/AlgoliaSearchClient/Command/Command+Insights.swift
+++ b/Sources/AlgoliaSearchClient/Command/Command+Insights.swift
@@ -22,9 +22,9 @@ extension Command {
 
       init(events: [InsightsEvent], requestOptions: RequestOptions?) {
         let body = EventsWrapper(events)
-        var updatedRequestOptions = requestOptions ?? .init()
-        updatedRequestOptions.setHeader("application/json", forKey: .contentType)
-        self.requestOptions = updatedRequestOptions
+        var requestOptions = requestOptions.unwrapOrCreate()
+        requestOptions.setHeader("application/json", forKey: .contentType)
+        self.requestOptions = requestOptions
         self.urlRequest = .init(method: .post, path: Path.eventsV1, body: body.httpBody, requestOptions: self.requestOptions)
       }
 

--- a/Tests/AlgoliaSearchClientTests/Unit/Command/InsightsCommandTest.swift
+++ b/Tests/AlgoliaSearchClientTests/Unit/Command/InsightsCommandTest.swift
@@ -1,0 +1,32 @@
+//
+//  InsightsCommandTest.swift
+//  
+//
+//  Created by Vladislav Fitc on 21/12/2020.
+//
+
+import Foundation
+import XCTest
+@testable import AlgoliaSearchClient
+
+class InsightsCommandTest: XCTestCase, AlgoliaCommandTest {
+  
+  func testSendEvents() throws {
+    let event = try InsightsEvent.click(name: "Search User Clicked",
+                                        indexName: "testIndex",
+                                        userToken: "test_user_token",
+                                        queryID: "test query id",
+                                        objectIDsWithPositions: [("object1", 1)])
+    
+    let command = Command.Insights.SendEvents(events: [event], requestOptions: test.requestOptions)
+    check(command: command,
+          callType: .write,
+          method: .post,
+          urlPath: "/1/events",
+          queryItems: [.init(name: "testParameter", value: "testParameterValue")],
+          body: EventsWrapper([event]).httpBody,
+          additionalHeaders: [.contentType: "application/json"],
+          requestOptions: test.requestOptions)
+
+  }
+}


### PR DESCRIPTION
**Summary**
Move required `content-type` header from synchronous `InsightsClient.sendEvents` function to `Command.Insights.SendEvents` structure.

**Result**
Insights events sent correctly using async `sendEvents` method
