### PR TITLE
fix: Set the correct json decoding key for indexName field in the SearchResponse

### DIFF
--- a/Sources/AlgoliaSearchClient/Models/Search/Response/SearchResponse/SearchResponse+Codable.swift
+++ b/Sources/AlgoliaSearchClient/Models/Search/Response/SearchResponse/SearchResponse+Codable.swift
@@ -35,7 +35,7 @@ extension SearchResponse: Codable {
     case disjunctiveFacetsStorage = "disjunctiveFacets"
     case facetStatsStorage = "facets_stats"
     case cursor
-    case indexName
+    case indexName = "index"
     case processed
     case queryID
     case hierarchicalFacetsStorage = "hierarchicalFacets"


### PR DESCRIPTION
**Summary**

Fixes #731 