### PR TITLE
fix: Resolve conflict between TimeInterval convenient methods and DispatchTimeInterval

### DIFF
--- a/Sources/AlgoliaSearchClient/Helpers/FoundationConvenience/TimeInterval+Minutes.swift
+++ b/Sources/AlgoliaSearchClient/Helpers/FoundationConvenience/TimeInterval+Minutes.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public extension TimeInterval {
+extension TimeInterval {
 
   var milliseconds: Int64 {
     return Int64((self * 1000.0).rounded())
@@ -15,7 +15,7 @@ public extension TimeInterval {
 
 }
 
-public extension TimeInterval {
+extension TimeInterval {
 
   static let hour: TimeInterval = minute * 60
 
@@ -25,7 +25,7 @@ public extension TimeInterval {
 
 }
 
-public extension TimeInterval {
+extension TimeInterval {
 
   static let minute: TimeInterval = 60
 
@@ -35,7 +35,7 @@ public extension TimeInterval {
 
 }
 
-public extension TimeInterval {
+extension TimeInterval {
 
   static let second: TimeInterval = 1
 
@@ -45,7 +45,7 @@ public extension TimeInterval {
 
 }
 
-public extension TimeInterval {
+extension TimeInterval {
 
   static let day: TimeInterval = hour * 24
 

--- a/Tests/AlgoliaSearchClientTests/Doc/Methods/ABTestSnippets.swift
+++ b/Tests/AlgoliaSearchClientTests/Doc/Methods/ABTestSnippets.swift
@@ -53,7 +53,7 @@ extension ABTestSnippets {
     let analyticsClient = AnalyticsClient(appID: "YourApplicationID", apiKey: "YourAdminAPIKey")
     
     let abTest = ABTest(name: "myABTest",
-                        endAt: Date().addingTimeInterval(.day),
+                        endAt: Date().addingTimeInterval(24 * 60 * 60),
                         variantA: .init(indexName: "indexName1",
                                         trafficPercentage: 90,
                                         description: "a description"),
@@ -72,7 +72,7 @@ extension ABTestSnippets {
     let analyticsClient = AnalyticsClient(appID: "YourApplicationID", apiKey: "YourAdminAPIKey")
     
     let abTest = ABTest(name: "myABTest",
-                        endAt: Date().addingTimeInterval(.day),
+                        endAt: Date().addingTimeInterval(24 * 60 * 60),
                         variantA: .init(indexName: "indexName1",
                                         trafficPercentage: 90,
                                         description: "a description"),

--- a/Tests/AlgoliaSearchClientTests/Doc/Methods/APIKeysSnippets.swift
+++ b/Tests/AlgoliaSearchClientTests/Doc/Methods/APIKeysSnippets.swift
@@ -47,7 +47,7 @@ extension APIKeysSnippets {
 
     let parentAPIKey = APIKey("SearchOnlyApiKeyKeptPrivate")
     let restriction = SecuredAPIKeyRestriction()
-      .set(\.validUntil, to: Date().addingTimeInterval(.hour).timeIntervalSince1970)
+      .set(\.validUntil, to: Date().addingTimeInterval(60 * 60).timeIntervalSince1970)
     
     let publicKey = client.generateSecuredApiKey(parentApiKey: parentAPIKey, with: restriction)
     _ = publicKey//to remove when pasted to doc

--- a/Tests/AlgoliaSearchClientTests/Doc/Methods/RulesSnippets.swift
+++ b/Tests/AlgoliaSearchClientTests/Doc/Methods/RulesSnippets.swift
@@ -37,7 +37,7 @@ extension RulesSnippets {
       )
       .set(\.validity, to: [
         TimeRange(from: Date(),
-                  until: Date().addingTimeInterval(.days(10)))
+                  until: Date().addingTimeInterval(10 * 24 * 60 * 60))
         ]
       )
     


### PR DESCRIPTION
**Summary**

The convenient TimeInterval methods defined in the extensions conflict with the methods defined for  `DispatchTimeInterval` type which leads to compile errors. 
This PR makes the TimeInterval convenience extension internal to avoid this conflict.

Fix #737 