### PR TITLE
feat(analytics): Add `abTestID` to the search response

### DIFF
--- a/Sources/AlgoliaSearchClient/Models/Search/Response/SearchResponse/SearchResponse+Codable.swift
+++ b/Sources/AlgoliaSearchClient/Models/Search/Response/SearchResponse/SearchResponse+Codable.swift
@@ -29,6 +29,7 @@ extension SearchResponse: Codable {
     case automaticRadius
     case serverUsed
     case indexUsed
+    case abTestID
     case abTestVariantID
     case parsedQuery
     case facetsStorage = "facets"
@@ -67,6 +68,7 @@ extension SearchResponse: Codable {
     self.automaticRadius = legacyAutomaticRadius.flatMap(Double.init)
     self.serverUsed = try container.decodeIfPresent(forKey: .serverUsed)
     self.indexUsed = try container.decodeIfPresent(forKey: .indexUsed)
+    self.abTestID = try container.decodeIfPresent(forKey: .abTestID)
     self.abTestVariantID = try container.decodeIfPresent(forKey: .abTestVariantID)
     self.parsedQuery = try container.decodeIfPresent(forKey: .parsedQuery)
     self.facetsStorage = try container.decodeIfPresent(forKey: .facetsStorage)
@@ -105,6 +107,7 @@ extension SearchResponse: Codable {
     try container.encodeIfPresent(legacyAutomaticRadius, forKey: .automaticRadius)
     try container.encodeIfPresent(serverUsed, forKey: .serverUsed)
     try container.encodeIfPresent(indexUsed, forKey: .indexUsed)
+    try container.encodeIfPresent(abTestID, forKey: .abTestID)
     try container.encodeIfPresent(abTestVariantID, forKey: .abTestVariantID)
     try container.encodeIfPresent(parsedQuery, forKey: .parsedQuery)
     try container.encodeIfPresent(facetsStorage, forKey: .facetsStorage)

--- a/Sources/AlgoliaSearchClient/Models/Search/Response/SearchResponse/SearchResponse.swift
+++ b/Sources/AlgoliaSearchClient/Models/Search/Response/SearchResponse/SearchResponse.swift
@@ -119,6 +119,12 @@ public struct SearchResponse {
    - Returned only if Query.getRankingInfo is set to true.
   */
   public var indexUsed: IndexName?
+  
+  /**
+   In case of A/B test, reports the ID of the A/B test used.
+   - Returned only if [Query.getRankingInfo] is set to true.
+   */
+  public var abTestID: ABTestID?
 
   /**
    In case of A/B test, reports the variant ID used. The variant ID is the position in the array of variants


### PR DESCRIPTION
**Summary**

Adds `abTestID` field to the search response

Fix #748 