### PR TITLE
fix: Around precision url component conversion issue

### DIFF
--- a/Sources/AlgoliaSearchClient/Models/Search/Query/Auxiliary/AroundPrecision.swift
+++ b/Sources/AlgoliaSearchClient/Models/Search/Query/Auxiliary/AroundPrecision.swift
@@ -9,10 +9,10 @@ import Foundation
 
 public struct AroundPrecision: Codable, Equatable {
 
-  public let from: Double
-  public let value: Double
+  public let from: Int
+  public let value: Int
 
-  public init(from: Double, value: Double) {
+  public init(from: Int, value: Int) {
     self.from = from
     self.value = value
   }
@@ -21,9 +21,9 @@ public struct AroundPrecision: Codable, Equatable {
 
 extension AroundPrecision: ExpressibleByIntegerLiteral {
 
-  public init(integerLiteral value: UInt) {
+  public init(integerLiteral value: Int) {
     self.from = 0
-    self.value = Double(value)
+    self.value = value
   }
 
 }
@@ -32,7 +32,7 @@ extension AroundPrecision: ExpressibleByFloatLiteral {
 
   public init(floatLiteral value: Double) {
     self.from = 0
-    self.value = value
+    self.value = Int(value)
   }
 
 }

--- a/Tests/AlgoliaSearchClientTests/Unit/QueryTests.swift
+++ b/Tests/AlgoliaSearchClientTests/Unit/QueryTests.swift
@@ -124,7 +124,7 @@ class QueryTests: XCTestCase {
       "aroundLatLng=79.5,10.5",
       "aroundLatLngViaIP=true",
       "aroundRadius=80",
-      "aroundPrecision=%5B%7B%22from%22:0.0,%22value%22:1000.0%7D,%7B%22from%22:0.0,%22value%22:100000.0%7D%5D",
+      "aroundPrecision=%5B%7B%22from%22:0,%22value%22:1000%7D,%7B%22from%22:0,%22value%22:100000%7D%5D",
       "minimumAroundRadius=40",
       "insideBoundingBox=%5B%5B0.0,10.0,20.0,30.0%5D,%5B40.0,50.0,60.0,70.0%5D%5D",
       "insidePolygon=%5B%5B0.0,10.0,20.0,30.0,40.0,50.0%5D,%5B10.0,20.0,30.0,40.0,50.0,60.0%5D%5D",


### PR DESCRIPTION
**Summary**

The `aroundPrecision` value uses floating point types not supported by the engine.
This PR changes its type to Integer.
