### PR TITLE
fix(longAPIKey): Move API key to body if the key's length > 500 chars

### DIFF
--- a/Sources/AlgoliaSearchClient/Command/Command+ABTest.swift
+++ b/Sources/AlgoliaSearchClient/Command/Command+ABTest.swift
@@ -15,7 +15,7 @@ extension Command {
 
       let method: HTTPMethod = .post
       let callType: CallType = .write
-      let path: URL = .ABTestsV2
+      let path = URL.ABTestsV2
       let body: Data?
       let requestOptions: RequestOptions?
 
@@ -79,7 +79,7 @@ extension Command {
 
       let method: HTTPMethod = .get
       let callType: CallType = .read
-      let path: URL = .ABTestsV2
+      let path = URL.ABTestsV2
       let requestOptions: RequestOptions?
 
       init(offset: Int?, limit: Int?, requestOptions: RequestOptions?) {

--- a/Sources/AlgoliaSearchClient/Command/Command+APIKeys.swift
+++ b/Sources/AlgoliaSearchClient/Command/Command+APIKeys.swift
@@ -15,7 +15,7 @@ extension Command {
 
       let method: HTTPMethod = .post
       let callType: CallType = .write
-      let path: URL = .keysV1
+      let path = URL.keysV1
       let body: Data?
       let requestOptions: RequestOptions?
 
@@ -97,7 +97,7 @@ extension Command {
 
       let method: HTTPMethod = .get
       let callType: CallType = .read
-      let path: URL = .keysV1
+      let path = URL.keysV1
       let requestOptions: RequestOptions?
 
       init(requestOptions: RequestOptions?) {

--- a/Sources/AlgoliaSearchClient/Command/Command+Advanced.swift
+++ b/Sources/AlgoliaSearchClient/Command/Command+Advanced.swift
@@ -49,7 +49,7 @@ extension Command {
 
       let method: HTTPMethod = .get
       let callType: CallType = .read
-      let path: URL = .logs
+      let path = URL.logs
       let requestOptions: RequestOptions?
 
       init(indexName: IndexName?, offset: Int?, length: Int?, logType: LogType, requestOptions: RequestOptions?) {

--- a/Sources/AlgoliaSearchClient/Command/Command+Insights.swift
+++ b/Sources/AlgoliaSearchClient/Command/Command+Insights.swift
@@ -15,7 +15,7 @@ extension Command {
 
       let method: HTTPMethod = .post
       let callType: CallType = .write
-      let path: URL = .eventsV1
+      let path = URL.eventsV1
       let body: Data?
       let requestOptions: RequestOptions?
 

--- a/Sources/AlgoliaSearchClient/Command/Command+MultiCluster.swift
+++ b/Sources/AlgoliaSearchClient/Command/Command+MultiCluster.swift
@@ -15,7 +15,7 @@ extension Command {
 
       let method: HTTPMethod = .get
       let callType: CallType = .read
-      let path: URL = .clustersV1
+      let path = URL.clustersV1
       let requestOptions: RequestOptions?
 
       init(requestOptions: RequestOptions?) {
@@ -53,7 +53,7 @@ extension Command.MultiCluster {
 
       let method: HTTPMethod = .post
       let callType: CallType = .write
-      let path: URL = .clustersV1.appending(.mapping)
+      let path = URL.clustersV1.appending(.mapping)
       let body: Data?
       let requestOptions: RequestOptions?
 
@@ -105,7 +105,7 @@ extension Command.MultiCluster {
 
       let method: HTTPMethod = .get
       let callType: CallType = .read
-      let path: URL = .clustersV1
+      let path = URL.clustersV1
         .appending(.mapping)
         .appending(.top)
       let requestOptions: RequestOptions?
@@ -120,7 +120,7 @@ extension Command.MultiCluster {
 
       let method: HTTPMethod = .get
       let callType: CallType = .read
-      let path: URL = .clustersV1
+      let path = URL.clustersV1
         .appending(.mapping)
       let requestOptions: RequestOptions?
 
@@ -155,7 +155,7 @@ extension Command.MultiCluster {
 
       let method: HTTPMethod = .post
       let callType: CallType = .read
-      let path: URL = .clustersV1
+      let path = URL.clustersV1
         .appending(.mapping)
         .appending(.search)
       let body: Data?

--- a/Sources/AlgoliaSearchClient/Command/Command+MultipleIndex.swift
+++ b/Sources/AlgoliaSearchClient/Command/Command+MultipleIndex.swift
@@ -15,7 +15,7 @@ extension Command {
 
       let method: HTTPMethod = .get
       let callType: CallType = .read
-      let path: URL = .indexesV1
+      let path = URL.indexesV1
       let requestOptions: RequestOptions?
 
       init(requestOptions: RequestOptions?) {

--- a/Sources/AlgoliaSearchClient/Command/Command+Personalization.swift
+++ b/Sources/AlgoliaSearchClient/Command/Command+Personalization.swift
@@ -15,7 +15,7 @@ extension Command {
 
       let method: HTTPMethod = .get
       let callType: CallType = .read
-      let path: URL = .strategies.appending(.personalization)
+      let path = URL.strategies.appending(.personalization)
       let requestOptions: RequestOptions?
 
       init(requestOptions: RequestOptions?) {
@@ -28,7 +28,7 @@ extension Command {
 
       let method: HTTPMethod = .post
       let callType: CallType = .write
-      let path: URL = .strategies.appending(.personalization)
+      let path = URL.strategies.appending(.personalization)
       let body: Data?
       let requestOptions: RequestOptions?
 

--- a/Sources/AlgoliaSearchClient/Command/Command.swift
+++ b/Sources/AlgoliaSearchClient/Command/Command.swift
@@ -14,7 +14,7 @@ extension Command {
   struct Template: AlgoliaCommand {
     var method: HTTPMethod = .get
     let callType: CallType = .read
-    let path: URL = .indexesV1
+    let path = URL.indexesV1
     let body: Data?
     let requestOptions: RequestOptions? = nil
   }

--- a/Sources/AlgoliaSearchClient/Helpers/UserAgent/UserAgent.swift
+++ b/Sources/AlgoliaSearchClient/Helpers/UserAgent/UserAgent.swift
@@ -34,11 +34,11 @@ extension UserAgent: CustomStringConvertible {
 }
 
 extension UserAgent: UserAgentExtending {
-  
+
   public var userAgentExtension: String {
     return description
   }
-  
+
 }
 
 extension UserAgent {

--- a/Sources/AlgoliaSearchClient/Helpers/UserAgent/UserAgentController.swift
+++ b/Sources/AlgoliaSearchClient/Helpers/UserAgent/UserAgentController.swift
@@ -12,9 +12,9 @@ public struct UserAgentController {
   public static var userAgents: [UserAgent] {
     extensions.compactMap { $0 as? UserAgent }
   }
-  
+
   public internal(set) static var extensions: [UserAgentExtending] = [UserAgent.operatingSystem, UserAgent.library]
-  
+
   public static var httpHeaderValue: String {
     return extensions.map(\.userAgentExtension).joined(separator: "; ")
   }
@@ -24,7 +24,7 @@ public struct UserAgentController {
   public static func append(userAgent: UserAgent) {
     extensions.append(userAgent)
   }
-  
+
   /// Append user agent to include into each API call.
   public static func append(_ userAgentExtension: UserAgentExtending) {
     extensions.append(userAgentExtension)
@@ -33,8 +33,7 @@ public struct UserAgentController {
 }
 
 public protocol UserAgentExtending {
-  
-  var userAgentExtension: String { get }
-  
-}
 
+  var userAgentExtension: String { get }
+
+}

--- a/Sources/AlgoliaSearchClient/Transport/URLSession/URLRequest+Convenience.swift
+++ b/Sources/AlgoliaSearchClient/Transport/URLSession/URLRequest+Convenience.swift
@@ -109,9 +109,73 @@ extension URLRequest {
     }
 
     set {
-      self[header: .apiKey] = newValue?.rawValue
+      do {
+        try setAPIKey(newValue)
+      } catch let error {
+        Logger.error("Couldn't set API key in the request body due to error: \(error)")
+      }
     }
 
+  }
+
+  static let maxHeaderAPIKeyLength = 500
+
+  private mutating func setAPIKey(_ apiKey: APIKey?) throws {
+
+    guard let apiKeyValue = apiKey?.rawValue, apiKeyValue.count > URLRequest.maxHeaderAPIKeyLength else {
+      self[header: .apiKey] = apiKey?.rawValue
+      return
+    }
+
+    Logger.warning("The API length is > \(URLRequest.maxHeaderAPIKeyLength). Attempt to insert it into request body.")
+
+    guard let body = httpBody else {
+      throw APIKeyError.missingHTTPBody
+    }
+
+    let decodingResult = Result { try JSONDecoder().decode(JSON.self, from: body) }
+    guard case .success(let bodyJSON) = decodingResult else {
+      if case .failure(let error) = decodingResult {
+        throw APIKeyError.bodyDecodingJSONError(error)
+      }
+      return
+    }
+
+    guard case .dictionary(var jsonDictionary) = bodyJSON else {
+      throw APIKeyError.bodyNonKeyValueJSON
+    }
+
+    jsonDictionary["apiKey"] = .string(apiKeyValue)
+
+    let encodingResult = Result { try JSONEncoder().encode(jsonDictionary) }
+    guard case .success(let updatedBody) = encodingResult else {
+      if case .failure(let error) = encodingResult {
+        throw APIKeyError.bodyEncodingJSONError(error)
+      }
+      return
+    }
+
+    httpBody = updatedBody
+  }
+
+  enum APIKeyError: Error, CustomStringConvertible {
+    case missingHTTPBody
+    case bodyDecodingJSONError(Error)
+    case bodyNonKeyValueJSON
+    case bodyEncodingJSONError(Error)
+
+    var description: String {
+      switch self {
+      case .missingHTTPBody:
+        return "Request doesn't contain HTTP body"
+      case .bodyDecodingJSONError(let error):
+        return "HTTP body JSON decoding error: \(error)"
+      case .bodyEncodingJSONError(let error):
+        return "HTTP body JSON encoding error: \(error)"
+      case .bodyNonKeyValueJSON:
+        return "HTTP body JSON is not key-value type"
+      }
+    }
   }
 
 }

--- a/Tests/AlgoliaSearchClientTests/Unit/Transport/HostSwitcherTests.swift
+++ b/Tests/AlgoliaSearchClientTests/Unit/Transport/HostSwitcherTests.swift
@@ -17,7 +17,7 @@ class HostSwitcherTests: XCTestCase {
 
   func testSwitchHost() throws {
     let timeout: TimeInterval = 10
-    let request = URLRequest(command: Command.Custom(method: .post, callType: .write, path: .init(string: "/my/test/path")!, body: nil, requestOptions: nil))
+    let request = URLRequest(command: Command.Custom(method: .post, callType: .write, path: URL(string: "/my/test/path")!, body: nil, requestOptions: nil))
 
     for index in 0...20 {
       var host = RetryableHost(url: URL(string: "test\(index).algolia.com")!)


### PR DESCRIPTION
**Summary**

If the API key's length is bigger than 500 characters it cannot be sent via request header. 
This PR adds the logic which moves the API key to the request body (if applicable) in this case. 

Fixes #766 