### PR TITLE
fix: Change ObjectsResponse results type constraint Codable -> Decodable 

### DIFF
--- a/Sources/AlgoliaSearchClient/Models/Search/Response/ObjectsResponse.swift
+++ b/Sources/AlgoliaSearchClient/Models/Search/Response/ObjectsResponse.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct ObjectsResponse<T: Codable>: Codable {
+public struct ObjectsResponse<T: Decodable>: Decodable {
 
   /// List of requested records. If a record is not found, it will be marked as null in the list.
   public let results: [T?]


### PR DESCRIPTION
**Summary**

The generic T type used for `results` value of the `ObjectsResponse` type has a `Codable` (alias for `Encodable & Decodable`) constraint, while the `Decodable` constraint is enough.
Reported [here](https://algolia.atlassian.net/jira/software/c/projects/CR/boards/189?modal=detail&selectedIssue=CR-565&quickFilter=459)

**Result**

Possibility to use types conforming to `Decodable`  in `ObjectsResponse` instead of `Encodable & Decodable`.