### PR TITLE
fix: Optional avg and sum fields in facet stats

### DIFF
--- a/Sources/AlgoliaSearchClient/Models/Search/Response/SearchResponse/Auxiliary/FacetStats/FacetStats.swift
+++ b/Sources/AlgoliaSearchClient/Models/Search/Response/SearchResponse/Auxiliary/FacetStats/FacetStats.swift
@@ -18,9 +18,9 @@ public struct FacetStats: Codable {
   public let max: Double
 
   /// The average of all values.
-  public let avg: Double
+  public let avg: Double?
 
   /// The sum of all values.
-  public let sum: Double
+  public let sum: Double?
 
 }

--- a/Tests/AlgoliaSearchClientTests/Unit/Model/FacetStats.swift
+++ b/Tests/AlgoliaSearchClientTests/Unit/Model/FacetStats.swift
@@ -1,0 +1,44 @@
+//
+//  FacetStats.swift
+//  
+//
+//  Created by Vladislav Fitc on 16/03/2022.
+//
+
+import Foundation
+import XCTest
+@testable import AlgoliaSearchClient
+
+class FacetStatsTests: XCTestCase {
+  
+  func testDecoding() throws {
+    let jsonData = """
+    {
+      "min": 10,
+      "max": 200,
+      "avg": 105,
+      "sum": 210,
+    }
+    """.data(using: .utf8)!
+    let facetStats = try JSONDecoder().decode(FacetStats.self, from: jsonData)
+    XCTAssertEqual(facetStats.min, 10)
+    XCTAssertEqual(facetStats.max, 200)
+    XCTAssertEqual(facetStats.avg, 105)
+    XCTAssertEqual(facetStats.sum, 210)
+  }
+  
+  func testMissingSumAvgDecoding() throws {
+    let jsonData = """
+    {
+      "min": 10,
+      "max": 200,
+    }
+    """.data(using: .utf8)!
+    let facetStats = try JSONDecoder().decode(FacetStats.self, from: jsonData)
+    XCTAssertEqual(facetStats.min, 10)
+    XCTAssertEqual(facetStats.max, 200)
+    XCTAssertNil(facetStats.avg)
+    XCTAssertNil(facetStats.sum)
+  }
+  
+}


### PR DESCRIPTION
**Summary**

This PR makes the `avg` and `sum` fields of the `FacetStats` structure optional. 
The engine may not return these values in case of overflow of the `sum` value resulting to the whole `SearchResponse` decoding failure. 