### PR TITLE
refactor: rename Task -> IndexTask

### DIFF
--- a/Sources/AlgoliaSearchClient/Client/AccountClient.swift
+++ b/Sources/AlgoliaSearchClient/Client/AccountClient.swift
@@ -33,7 +33,7 @@ public struct AccountClient {
   @discardableResult public static func copyIndex(source: Index,
                                                   destination: Index,
                                                   requestOptions: RequestOptions? = nil,
-                                                  completion: @escaping (Result<WaitableWrapper<[Task]>, Swift.Error>) -> Void) throws -> Operation {
+                                                  completion: @escaping (Result<WaitableWrapper<[IndexTask]>, Swift.Error>) -> Void) throws -> Operation {
     let operation = BlockOperation {
       completion(.init { try AccountClient.copyIndex(source: source, destination: destination, requestOptions: requestOptions) })
     }
@@ -54,7 +54,7 @@ public struct AccountClient {
 
   @discardableResult public static func copyIndex(source: Index,
                                                   destination: Index,
-                                                  requestOptions: RequestOptions? = nil) throws -> WaitableWrapper<[Task]> {
+                                                  requestOptions: RequestOptions? = nil) throws -> WaitableWrapper<[IndexTask]> {
 
     guard source.applicationID != destination.applicationID else {
       throw Error.sameApplicationID
@@ -78,7 +78,7 @@ public struct AccountClient {
     let waitRules = try destination.saveRules(rules)
     let waitSettings = try destination.setSettings(settings)
 
-    let tasks: [Task] = [
+    let tasks: [IndexTask] = [
       waitSynonyms,
       waitRules,
       waitSettings

--- a/Sources/AlgoliaSearchClient/Helpers/ResultCallback.swift
+++ b/Sources/AlgoliaSearchClient/Helpers/ResultCallback.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 public typealias ResultCallback<T> = (Result<T, Error>) -> Void
-public typealias ResultTaskCallback<T: Task & Codable> = (Result<WaitableWrapper<T>, Error>) -> Void
+public typealias ResultTaskCallback<T: IndexTask & Codable> = (Result<WaitableWrapper<T>, Error>) -> Void
 public typealias ResultAppTaskCallback<T: AppTask & Codable> = (Result<WaitableWrapper<T>, Error>) -> Void
 public typealias ResultBatchesCallback = (Result<WaitableWrapper<BatchesResponse>, Error>) -> Void

--- a/Sources/AlgoliaSearchClient/Helpers/Wait/WaitableWrapper.swift
+++ b/Sources/AlgoliaSearchClient/Helpers/Wait/WaitableWrapper.swift
@@ -19,7 +19,7 @@ public struct WaitableWrapper<T> {
 
 }
 
-extension WaitableWrapper where T: Task {
+extension WaitableWrapper where T: IndexTask {
 
   public var task: T {
     return wrapped
@@ -38,13 +38,13 @@ extension WaitableWrapper where T: Task {
 
 }
 
-extension WaitableWrapper where T == [Task] {
+extension WaitableWrapper where T == [IndexTask] {
 
   public var tasks: T {
     return wrapped
   }
 
-  init(tasks: [Task], index: Index) {
+  init(tasks: [IndexTask], index: Index) {
     self.wrapped = tasks
     self.tasksToWait = tasks.map { Waitable(index: index, taskID: $0.taskID) }
   }
@@ -70,7 +70,7 @@ extension WaitableWrapper where T: AppTask {
 
 }
 
-extension WaitableWrapper where T: Task & IndexNameContainer {
+extension WaitableWrapper where T: IndexTask & IndexNameContainer {
 
   static func wrap(credentials: Credentials) -> (T) -> WaitableWrapper<T> {
     return { task in

--- a/Sources/AlgoliaSearchClient/Index/Index+Advanced.swift
+++ b/Sources/AlgoliaSearchClient/Index/Index+Advanced.swift
@@ -9,12 +9,12 @@ import Foundation
 
 public extension Index {
 
-  // MARK: - Task status
+  // MARK: - IndexTask status
 
   /**
-    Check the current TaskStatus of a given Task.
+    Check the current TaskStatus of a given IndexTask.
    
-    - parameter taskID: of the indexing [Task].
+    - parameter taskID: of the indexing [IndexTask].
     - parameter requestOptions: Configure request locally with [RequestOptions]
   */
   @discardableResult func taskStatus(for taskID: TaskID,
@@ -25,9 +25,9 @@ public extension Index {
   }
 
   /**
-    Check the current TaskStatus of a given Task.
+    Check the current TaskStatus of a given IndexTask.
    
-    - parameter taskID: of the indexing [Task].
+    - parameter taskID: of the indexing [IndexTask].
     - parameter requestOptions: Configure request locally with [RequestOptions]
   */
   @discardableResult func taskStatus(for taskID: TaskID,
@@ -39,7 +39,7 @@ public extension Index {
   // MARK: - Wait task
 
   /**
-    Wait for a Task to complete before executing the next line of code, to synchronize index updates.
+    Wait for a IndexTask to complete before executing the next line of code, to synchronize index updates.
     All write operations in Algolia are asynchronous by design.
     It means that when you add or update an object to your index, our servers will reply to your request with
     a TaskID as soon as they understood the write operation.
@@ -63,7 +63,7 @@ public extension Index {
   }
 
   /**
-    Wait for a Task to complete before executing the next line of code, to synchronize index updates.
+    Wait for a IndexTask to complete before executing the next line of code, to synchronize index updates.
     All write operations in Algolia are asynchronous by design.
     It means that when you add or update an object to your index, our servers will reply to your request with
     a TaskID as soon as they understood the write operation.

--- a/Sources/AlgoliaSearchClient/Index/Index.swift
+++ b/Sources/AlgoliaSearchClient/Index/Index.swift
@@ -35,11 +35,11 @@ extension Index: TransportContainer {}
 
 extension Index {
 
-  func execute<Command: AlgoliaCommand, Output: Codable & Task>(_ command: Command, completion: @escaping ResultTaskCallback<Output>) -> Operation & TransportTask {
+  func execute<Command: AlgoliaCommand, Output: Codable & IndexTask>(_ command: Command, completion: @escaping ResultTaskCallback<Output>) -> Operation & TransportTask {
     transport.execute(command, transform: WaitableWrapper.wrap(with: self), completion: completion)
   }
 
-  func execute<Command: AlgoliaCommand, Output: Codable & Task>(_ command: Command) throws -> WaitableWrapper<Output> {
+  func execute<Command: AlgoliaCommand, Output: Codable & IndexTask>(_ command: Command) throws -> WaitableWrapper<Output> {
     try transport.execute(command, transform: WaitableWrapper.wrap(with: self))
   }
 

--- a/Sources/AlgoliaSearchClient/Models/Analytics/ABTest/Task/ABTestCreation.swift
+++ b/Sources/AlgoliaSearchClient/Models/Analytics/ABTest/Task/ABTestCreation.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct ABTestCreation: Task, IndexNameContainer, Codable {
+public struct ABTestCreation: IndexTask, IndexNameContainer, Codable {
 
   /// Generated ABTestID of the ABTest.
   public let abTestID: ABTestID

--- a/Sources/AlgoliaSearchClient/Models/Analytics/ABTest/Task/ABTestDeletion.swift
+++ b/Sources/AlgoliaSearchClient/Models/Analytics/ABTest/Task/ABTestDeletion.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct ABTestDeletion: Task, Codable, IndexNameContainer {
+public struct ABTestDeletion: IndexTask, Codable, IndexNameContainer {
 
   /// Generated ABTestID of the ABTest.
   public let abTestID: ABTestID

--- a/Sources/AlgoliaSearchClient/Models/Analytics/ABTest/Task/ABTestRevision.swift
+++ b/Sources/AlgoliaSearchClient/Models/Analytics/ABTest/Task/ABTestRevision.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct ABTestRevision: Task, IndexNameContainer, Codable {
+public struct ABTestRevision: IndexTask, IndexNameContainer, Codable {
 
   /// Generated ABTestID of the ABTest.
   public let abTestID: ABTestID

--- a/Sources/AlgoliaSearchClient/Models/Common/Revision.swift
+++ b/Sources/AlgoliaSearchClient/Models/Common/Revision.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct Revision: Task, Codable {
+public struct Revision: IndexTask, Codable {
 
   /// Date at which the update happened.
   public let updatedAt: Date

--- a/Sources/AlgoliaSearchClient/Models/Search/Indexing/Batch/BatchResponse.swift
+++ b/Sources/AlgoliaSearchClient/Models/Search/Indexing/Batch/BatchResponse.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct BatchResponse: Codable, Task {
+public struct BatchResponse: Codable, IndexTask {
 
   public let taskID: TaskID
   public let objectIDs: [ObjectID?]

--- a/Sources/AlgoliaSearchClient/Models/Synonym/SynonymRevision.swift
+++ b/Sources/AlgoliaSearchClient/Models/Synonym/SynonymRevision.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct SynonymRevision: Task {
+public struct SynonymRevision: IndexTask {
 
   /// Date at which the Task to update the synonyms has been created.
   public let updatedAt: Date

--- a/Sources/AlgoliaSearchClient/Models/Task/Common/IndexTask.swift
+++ b/Sources/AlgoliaSearchClient/Models/Task/Common/IndexTask.swift
@@ -1,5 +1,5 @@
 //
-//  Task.swift
+//  IndexTask.swift
 //  
 //
 //  Created by Vladislav Fitc on 02/03/2020.
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public protocol Task {
+public protocol IndexTask {
 
   var taskID: TaskID { get }
 

--- a/Sources/AlgoliaSearchClient/Models/Task/Index/IndexDeletion.swift
+++ b/Sources/AlgoliaSearchClient/Models/Task/Index/IndexDeletion.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct IndexDeletion: Task, Codable {
+public struct IndexDeletion: IndexTask, Codable {
 
   /// Date at which the Task to delete the Index has been created.
   public let deletionDate: Date

--- a/Sources/AlgoliaSearchClient/Models/Task/Index/IndexRevision.swift
+++ b/Sources/AlgoliaSearchClient/Models/Task/Index/IndexRevision.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct IndexRevision: Task, Codable {
+public struct IndexRevision: IndexTask, Codable {
 
   /// Date at which the Task to update the Index has been created.
   public let updatedAt: Date

--- a/Sources/AlgoliaSearchClient/Models/Task/Index/IndexedTask.swift
+++ b/Sources/AlgoliaSearchClient/Models/Task/Index/IndexedTask.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct IndexedTask: Task {
+public struct IndexedTask: IndexTask {
 
   /// The name of the index this task is running on.
   public let indexName: IndexName

--- a/Sources/AlgoliaSearchClient/Models/Task/Object/ObjectCreation.swift
+++ b/Sources/AlgoliaSearchClient/Models/Task/Object/ObjectCreation.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct ObjectCreation: Task, Codable {
+public struct ObjectCreation: IndexTask, Codable {
 
   /// The date at which the record has been created.
   public let createdAt: Date

--- a/Sources/AlgoliaSearchClient/Models/Task/Object/ObjectDeletion.swift
+++ b/Sources/AlgoliaSearchClient/Models/Task/Object/ObjectDeletion.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct ObjectDeletion: Task, Codable {
+public struct ObjectDeletion: IndexTask, Codable {
 
   /// The date at which the record has been deleted.
   public let deletedAt: Date

--- a/Sources/AlgoliaSearchClient/Models/Task/Object/ObjectRevision.swift
+++ b/Sources/AlgoliaSearchClient/Models/Task/Object/ObjectRevision.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct ObjectRevision: Task, Codable {
+public struct ObjectRevision: IndexTask, Codable {
 
   /// The date at which the record has been revised.
   public let updatedAt: Date

--- a/Sources/AlgoliaSearchClient/Transport/Common/TransportContainer.swift
+++ b/Sources/AlgoliaSearchClient/Transport/Common/TransportContainer.swift
@@ -62,11 +62,11 @@ extension TransportContainer {
 
 extension TransportContainer where Self: Credentials {
 
-  func execute<Command: AlgoliaCommand, Output: Decodable & Task & IndexNameContainer>(_ command: Command, completion: @escaping ResultTaskCallback<Output>) -> Operation & TransportTask {
+  func execute<Command: AlgoliaCommand, Output: Decodable & IndexTask & IndexNameContainer>(_ command: Command, completion: @escaping ResultTaskCallback<Output>) -> Operation & TransportTask {
     transport.execute(command, transform: WaitableWrapper.wrap(credentials: self), completion: completion)
   }
 
-  func execute<Command: AlgoliaCommand, Output: Decodable & Task & IndexNameContainer>(_ command: Command) throws -> WaitableWrapper<Output> {
+  func execute<Command: AlgoliaCommand, Output: Decodable & IndexTask & IndexNameContainer>(_ command: Command) throws -> WaitableWrapper<Output> {
     try transport.execute(command, transform: WaitableWrapper.wrap(credentials: self))
   }
 

--- a/Tests/AlgoliaSearchClientTests/Doc/Methods/ManageIndicesSnippets.swift
+++ b/Tests/AlgoliaSearchClientTests/Doc/Methods/ManageIndicesSnippets.swift
@@ -69,7 +69,7 @@ extension ManageIndicesSnippets {
     [source](#method-param-indexsrc): __Index__,
     [destination](#method-param-indexdest): __Index__,
     requestOptions: RequestOptions? = nil,
-    completion: __Result<WaitableWrapper<[Task]>, Swift.Error>) -> Void__
+    completion: __Result<WaitableWrapper<[IndexTask]>, Swift.Error>) -> Void__
   )
   """
   


### PR DESCRIPTION
**Summary**

The `Task` protocol used in the client conflicts with the [`Task`](https://developer.apple.com/documentation/swift/task) structure introduced with the Swift concurrency.
This PR renames the protocol  `Task` to `IndexTask`.
The introduced naming is also more consistent, as the client contains the `AppTask` protocol used for [custom dictionaries method](https://github.com/algolia/algoliasearch-client-swift/pull/717). 
While this change seems to be breaking, it doesn't affect the final implementations, as the protocol is not designed to be used directly, it's used as a generic constraint internally. 