### PR TITLE
chore: update host for Personalization Client

### DIFF
--- a/Sources/AlgoliaSearchClient/Models/Common/Region.swift
+++ b/Sources/AlgoliaSearchClient/Models/Common/Region.swift
@@ -4,6 +4,7 @@
 //
 //  Created by Vladislav Fitc on 23/04/2020.
 //
+// swiftlint:disable identifier_name
 
 import Foundation
 

--- a/Sources/AlgoliaSearchClient/Models/Common/Region.swift
+++ b/Sources/AlgoliaSearchClient/Models/Common/Region.swift
@@ -10,10 +10,10 @@ import Foundation
 public struct Region: StringOption, ProvidingCustomOption {
 
   public static var us: Self { .init(rawValue: #function) }
-  
+
   /// European (Germany) region for Insights and Analytics APIs
   public static var de: Self { .init(rawValue: #function) }
-  
+
   /// European region for Personalization API
   public static var eu: Self { .init(rawValue: #function) }
 

--- a/Sources/AlgoliaSearchClient/Models/Common/Region.swift
+++ b/Sources/AlgoliaSearchClient/Models/Common/Region.swift
@@ -10,7 +10,12 @@ import Foundation
 public struct Region: StringOption, ProvidingCustomOption {
 
   public static var us: Self { .init(rawValue: #function) }
+  
+  /// European (Germany) region for Insights and Analytics APIs
   public static var de: Self { .init(rawValue: #function) }
+  
+  /// European region for Personalization API
+  public static var eu: Self { .init(rawValue: #function) }
 
   public let rawValue: String
 

--- a/Sources/AlgoliaSearchClient/Models/Internal/Hosts.swift
+++ b/Sources/AlgoliaSearchClient/Models/Internal/Hosts.swift
@@ -34,10 +34,17 @@ public struct Hosts {
     return [.init(url: URL(string: "insights\(regionComponent).algolia.io")!)]
   }
 
+  @available(*, deprecated, renamed: "personalization(forRegion:)")
   public static func recommendation(forRegion region: Region? = nil) -> [RetryableHost] {
     let regionComponent = region.flatMap { ".\($0.rawValue)" } ?? ""
     return [.init(url: URL(string: "recommendation\(regionComponent).algolia.com")!)]
   }
+  
+  public static func personalization(forRegion region: Region? = nil) -> [RetryableHost] {
+    let regionComponent = region.flatMap { ".\($0.rawValue)" } ?? ""
+    return [.init(url: URL(string: "personalization\(regionComponent).algolia.com")!)]
+  }
+
 
   public static var analytics: [RetryableHost] = [
     .init(url: URL(string: "analytics.algolia.com")!)

--- a/Sources/AlgoliaSearchClient/Models/Internal/Hosts.swift
+++ b/Sources/AlgoliaSearchClient/Models/Internal/Hosts.swift
@@ -39,12 +39,11 @@ public struct Hosts {
     let regionComponent = region.flatMap { ".\($0.rawValue)" } ?? ""
     return [.init(url: URL(string: "recommendation\(regionComponent).algolia.com")!)]
   }
-  
+
   public static func personalization(forRegion region: Region? = nil) -> [RetryableHost] {
     let regionComponent = region.flatMap { ".\($0.rawValue)" } ?? ""
     return [.init(url: URL(string: "personalization\(regionComponent).algolia.com")!)]
   }
-
 
   public static var analytics: [RetryableHost] = [
     .init(url: URL(string: "analytics.algolia.com")!)

--- a/Sources/AlgoliaSearchClient/Models/Personalization/PersonalizationConfiguration.swift
+++ b/Sources/AlgoliaSearchClient/Models/Personalization/PersonalizationConfiguration.swift
@@ -38,7 +38,7 @@ public struct PersonalizationConfiguration: Configuration, Credentials {
     self.writeTimeout = writeTimeout
     self.readTimeout = readTimeout
     self.logLevel = logLevel
-    self.hosts = Hosts.recommendation(forRegion: region)
+    self.hosts = Hosts.personalization(forRegion: region)
     self.defaultHeaders = defaultHeaders
     self.batchSize = batchSize
   }

--- a/Tests/AlgoliaSearchClientTests/Integration/PersonalizationIntegrationTests.swift
+++ b/Tests/AlgoliaSearchClientTests/Integration/PersonalizationIntegrationTests.swift
@@ -19,13 +19,13 @@ class PersonalizationIntegrationTests: IntegrationTestCase {
   }
 
   func getStrategy() throws {
-    let recommendationClient = PersonalizationClient(appID: client.applicationID, apiKey: client.apiKey, region: .eu)
+    let recommendationClient = PersonalizationClient(appID: client.applicationID, apiKey: client.apiKey, region: .custom("us"))
     let _ = try recommendationClient.getPersonalizationStrategy()
   }
   
   func setStrategy() throws {
     
-    let personalizationClient = PersonalizationClient(appID: client.applicationID, apiKey: client.apiKey, region: .eu)
+    let personalizationClient = PersonalizationClient(appID: client.applicationID, apiKey: client.apiKey, region: .custom("us"))
 
     let strategy = PersonalizationStrategy(
       eventsScoring: [

--- a/Tests/AlgoliaSearchClientTests/Integration/PersonalizationIntegrationTests.swift
+++ b/Tests/AlgoliaSearchClientTests/Integration/PersonalizationIntegrationTests.swift
@@ -19,13 +19,13 @@ class PersonalizationIntegrationTests: IntegrationTestCase {
   }
 
   func getStrategy() throws {
-    let recommendationClient = PersonalizationClient(appID: client.applicationID, apiKey: client.apiKey, region: .custom("us"))
+    let recommendationClient = PersonalizationClient(appID: client.applicationID, apiKey: client.apiKey, region: .eu)
     let _ = try recommendationClient.getPersonalizationStrategy()
   }
   
   func setStrategy() throws {
     
-    let personalizationClient = PersonalizationClient(appID: client.applicationID, apiKey: client.apiKey, region: .custom("us"))
+    let personalizationClient = PersonalizationClient(appID: client.applicationID, apiKey: client.apiKey, region: .eu)
 
     let strategy = PersonalizationStrategy(
       eventsScoring: [


### PR DESCRIPTION
**Summary**

- Replace the legacy `recommendation` host with `personalization` host for Personalization client
- Add convenient "eu" constant for `Region` type to use with Personalization client