### PR TITLE
feat(rules): add applied rules to the search response

### DIFF
--- a/Sources/AlgoliaSearchClient/Models/Search/Response/SearchResponse/SearchResponse+Codable.swift
+++ b/Sources/AlgoliaSearchClient/Models/Search/Response/SearchResponse/SearchResponse+Codable.swift
@@ -41,6 +41,7 @@ extension SearchResponse: Codable {
     case queryID
     case hierarchicalFacetsStorage = "hierarchicalFacets"
     case explain
+    case appliedRules
     case renderingContent
     case appliedRelevancyStrictness
     case nbSortedHits
@@ -80,6 +81,7 @@ extension SearchResponse: Codable {
     self.queryID = try container.decodeIfPresent(forKey: .queryID)
     self.hierarchicalFacetsStorage = try container.decodeIfPresent(forKey: .hierarchicalFacetsStorage)
     self.explain = try container.decodeIfPresent(forKey: .explain)
+    self.appliedRules = try container.decodeIfPresent(forKey: .appliedRules)
     self.renderingContent = try container.decodeIfPresent(forKey: .renderingContent)
     self.appliedRelevancyStrictness = try container.decodeIfPresent(forKey: .appliedRelevancyStrictness)
     self.nbSortedHits = try container.decodeIfPresent(forKey: .nbSortedHits)
@@ -119,6 +121,7 @@ extension SearchResponse: Codable {
     try container.encodeIfPresent(queryID, forKey: .queryID)
     try container.encodeIfPresent(hierarchicalFacetsStorage, forKey: .hierarchicalFacetsStorage)
     try container.encodeIfPresent(explain, forKey: .explain)
+    try container.encodeIfPresent(appliedRules, forKey: .appliedRules)
     try container.encodeIfPresent(renderingContent, forKey: .renderingContent)
     try container.encodeIfPresent(appliedRelevancyStrictness, forKey: .appliedRelevancyStrictness)
     try container.encodeIfPresent(nbSortedHits, forKey: .nbSortedHits)

--- a/Sources/AlgoliaSearchClient/Models/Search/Response/SearchResponse/SearchResponse.swift
+++ b/Sources/AlgoliaSearchClient/Models/Search/Response/SearchResponse/SearchResponse.swift
@@ -230,6 +230,11 @@ public struct SearchResponse {
    Meta-information as to how the query was processed.
   */
   public var explain: Explain?
+  
+  /**
+   The rules applied to the query.
+   */
+  public var appliedRules: [JSON]?
 
   /**
    The relevancy threshold applied to search in a virtual index.


### PR DESCRIPTION
**Summary**

This PR adds `appliedRules` field to the search response structure.

**Result**

Rules applied to query are accessible from the search response

