### PR TITLE
fix: added conditional FoundationNetworking import

### DIFF
--- a/Sources/AlgoliaSearchClient/Transport/RetryStrategy/AlgoliaRetryStrategy.swift
+++ b/Sources/AlgoliaSearchClient/Transport/RetryStrategy/AlgoliaRetryStrategy.swift
@@ -6,6 +6,10 @@
 //
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
 
 /** Algolia's retry strategy in case of server error, timeouts... */
 


### PR DESCRIPTION
Hello!

I was trying to compile this client as a dependency on a server-side application running on Linux. I would get an error that `URLRequest` was not defined in the file `AlgoliaRetryStrategy.swift`. I believe this was due to the lack of a conditional import of `FoundationNetworking`, so this PR just adds that.

This library now seems to compile correctly on Linux with this change.

Thanks for all the work on this client!