### PR TITLE
fix: matching errors in the retry strategy

### DIFF
--- a/Sources/AlgoliaSearchClient/Transport/RetryStrategy/AlgoliaRetryStrategy.swift
+++ b/Sources/AlgoliaSearchClient/Transport/RetryStrategy/AlgoliaRetryStrategy.swift
@@ -10,7 +10,6 @@ import Foundation
 import FoundationNetworking
 #endif
 
-
 /** Algolia's retry strategy in case of server error, timeouts... */
 
 class AlgoliaRetryStrategy: RetryStrategy {
@@ -78,7 +77,7 @@ class AlgoliaRetryStrategy: RetryStrategy {
     switch error {
     case .requestError(let error) as TransportError where error is URLError:
       return true
-      
+
     case .httpError(let httpError) as TransportError where !httpError.statusCode.belongs(to: .success, .clientError):
       return true
 
@@ -94,10 +93,10 @@ class AlgoliaRetryStrategy: RetryStrategy {
     switch error {
     case .requestError(let error as URLError) as TransportError where error.code == .timedOut:
       return true
-      
+
     case .httpError(let error) as TransportError where error.statusCode == .requestTimeout:
       return true
-  
+
     default:
       return false
     }

--- a/Tests/AlgoliaSearchClientTests/Integration/PersonalizationIntegrationTests.swift
+++ b/Tests/AlgoliaSearchClientTests/Integration/PersonalizationIntegrationTests.swift
@@ -41,7 +41,7 @@ class PersonalizationIntegrationTests: IntegrationTestCase {
 
     do {
       try personalizationClient.setPersonalizationStrategy(strategy)
-    } catch let httpError as HTTPError where httpError.statusCode == HTTPStatusСode.tooManyRequests {
+    } catch .httpError(let httpError) as TransportError where httpError.statusCode == HTTPStatusСode.tooManyRequests {
       // The personalization API is now limiting the number of setPersonalizationStrategy()` successful calls
       // to 15 per day. If the 429 error is returned, the response is considered a "success".
     } catch let error {

--- a/Tests/AlgoliaSearchClientTests/Unit/Transport/AlgoliaRetryStrategyTests.swift
+++ b/Tests/AlgoliaSearchClientTests/Unit/Transport/AlgoliaRetryStrategyTests.swift
@@ -18,8 +18,8 @@ class AlgoliaRetryStrategyTests: XCTestCase {
   let host5 = RetryableHost(url: URL(string: "algolia5.com")!, callType: .read)
 
   let successResult = Result<String, Error>.success("success")
-  let retryableErrorResult = Result<String, Error>.failure(URLError(.networkConnectionLost))
-  let timeoutErrorResult = Result<String, Error>.failure(URLError(.timedOut))
+  let retryableErrorResult = Result<String, Error>.failure(TransportError.requestError(URLError(.networkConnectionLost)))
+  let timeoutErrorResult = Result<String, Error>.failure(TransportError.requestError(URLError(.timedOut)))
 
   func testHostsRotation() {
 


### PR DESCRIPTION
**Summary**

This PR fixes pattern matching issue in the retry strategy that causes incorrect operation of the retry strategy in some cases.

**Result**

Retry strategy works correctly.