### PR TITLE
fix(search): disjunctive faceting helper

### DIFF
--- a/Sources/AlgoliaSearchClient/Helpers/DisjunctiveFacetingHelper.swift
+++ b/Sources/AlgoliaSearchClient/Helpers/DisjunctiveFacetingHelper.swift
@@ -50,22 +50,28 @@ struct DisjunctiveFacetingHelper {
     var queries = [Query]()
 
     var mainQuery = query
-    if let mainQueryFilters = mainQuery.filters, !mainQueryFilters.isEmpty {
-      mainQuery.filters = mainQueryFilters + " AND "
-    }
-    mainQuery.filters = (mainQuery.filters ?? "") + buildFilters(excluding: .none)
+    mainQuery.filters = [
+        mainQuery.filters,
+        buildFilters(excluding: .none)
+    ]
+          .compactMap { $0 }
+          .filter { !$0.isEmpty }
+          .joined(separator: " AND ")
 
     queries.append(mainQuery)
 
     disjunctiveFacets
       .sorted(by: { $0.rawValue < $1.rawValue })
       .forEach { disjunctiveFacet in
-      var disjunctiveQuery = query
-      disjunctiveQuery.facets = [disjunctiveFacet]
-      if let disjunctiveQueryFilters = disjunctiveQuery.filters, !disjunctiveQueryFilters.isEmpty {
-          disjunctiveQuery.filters = disjunctiveQueryFilters + " AND "
-      }
-      disjunctiveQuery.filters = (disjunctiveQuery.filters ?? "") + buildFilters(excluding: disjunctiveFacet)
+        var disjunctiveQuery = query
+          disjunctiveQuery.facets = [disjunctiveFacet]
+          disjunctiveQuery.filters = [
+            disjunctiveQuery.filters,
+            buildFilters(excluding: disjunctiveFacet)
+        ]
+              .compactMap { $0 }
+              .filter { !$0.isEmpty }
+              .joined(separator: " AND ")
       disjunctiveQuery.hitsPerPage = 0
       disjunctiveQuery.attributesToRetrieve = []
       disjunctiveQuery.attributesToHighlight = []

--- a/Sources/AlgoliaSearchClient/Helpers/DisjunctiveFacetingHelper.swift
+++ b/Sources/AlgoliaSearchClient/Helpers/DisjunctiveFacetingHelper.swift
@@ -50,7 +50,10 @@ struct DisjunctiveFacetingHelper {
     var queries = [Query]()
 
     var mainQuery = query
-    mainQuery.filters = buildFilters(excluding: .none)
+    if let mainQueryFilters = mainQuery.filters, !mainQueryFilters.isEmpty {
+      mainQuery.filters = mainQueryFilters + " AND "
+    }
+    mainQuery.filters = (mainQuery.filters ?? "") + buildFilters(excluding: .none)
 
     queries.append(mainQuery)
 
@@ -59,7 +62,10 @@ struct DisjunctiveFacetingHelper {
       .forEach { disjunctiveFacet in
       var disjunctiveQuery = query
       disjunctiveQuery.facets = [disjunctiveFacet]
-      disjunctiveQuery.filters = buildFilters(excluding: disjunctiveFacet)
+      if let disjunctiveQueryFilters = disjunctiveQuery.filters, !disjunctiveQueryFilters.isEmpty {
+          disjunctiveQuery.filters = disjunctiveQueryFilters + " AND "
+      }
+      disjunctiveQuery.filters = (disjunctiveQuery.filters ?? "") + buildFilters(excluding: disjunctiveFacet)
       disjunctiveQuery.hitsPerPage = 0
       disjunctiveQuery.attributesToRetrieve = []
       disjunctiveQuery.attributesToHighlight = []

--- a/Tests/AlgoliaSearchClientTests/Unit/DisjunctiveFacetingHelperTests.swift
+++ b/Tests/AlgoliaSearchClientTests/Unit/DisjunctiveFacetingHelperTests.swift
@@ -444,5 +444,30 @@ class DisjunctiveFacetingHelperTests: XCTestCase {
         ("brand":"apple" AND "brand":"samsung" AND "brand":"sony") AND ("color":"blue" OR "color":"green" OR "color":"red")
         """)
     }
+    
+    func testKeepExistingFiltersNoRefinement() throws {
+        var query = Query()
+        query.filters = "NOT color:blue"
 
+        let disjunctiveFacets: Set<Attribute> = [
+          "color",
+          "size"
+        ]
+        let helper = DisjunctiveFacetingHelper(query: query,
+                                               refinements: [:],
+                                               disjunctiveFacets: disjunctiveFacets)
+        let queries = helper.makeQueries()
+        XCTAssertEqual(queries.count, 3)
+        XCTAssertEqual(queries.first?.filters, """
+        NOT color:blue
+        """)
+        XCTAssertEqual(queries[1].facets, ["color"])
+        XCTAssertEqual(queries[1].filters, """
+        NOT color:blue
+        """)
+        XCTAssertEqual(queries[2].facets, ["size"])
+        XCTAssertEqual(queries[2].filters, """
+        NOT color:blue
+        """)
+    }
 }


### PR DESCRIPTION
**Summary**

Solves [DI-2708]

There was a discrepancy between v7 and v8 of the client where the helper began using the `filters` property instead of the `facetFilters` property, as recommended by the official Algolia documentation, but not taking into account that users may already be using the property.
We needed to make sure existing filters were preserved.

**Result**

The `filters` property is no longer overwritten.



[DI-2708]: https://algolia.atlassian.net/browse/DI-2708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ